### PR TITLE
[Feat] Auth api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/blockguard/server/domain/auth/api/AuthApi.java
+++ b/src/main/java/com/blockguard/server/domain/auth/api/AuthApi.java
@@ -1,8 +1,11 @@
 package com.blockguard.server.domain.auth.api;
 
 import com.blockguard.server.domain.auth.application.AuthService;
+import com.blockguard.server.domain.user.dto.request.FindEmailRequest;
+import com.blockguard.server.domain.user.dto.request.FindPasswordRequest;
 import com.blockguard.server.domain.user.dto.request.LoginRequest;
 import com.blockguard.server.domain.user.dto.request.RegisterRequest;
+import com.blockguard.server.domain.user.dto.response.FindEmailResponse;
 import com.blockguard.server.domain.user.dto.response.LoginResponse;
 import com.blockguard.server.domain.user.dto.response.RegisterResponse;
 import com.blockguard.server.global.common.codes.SuccessCode;
@@ -40,6 +43,14 @@ public class AuthApi {
     public ResponseEntity<BaseResponse<LoginResponse>> login(@RequestBody LoginRequest loginRequest) {
         LoginResponse loginResponse = authService.login(loginRequest);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.LOGIN_SUCCESS, loginResponse));
+    }
+
+    @Operation(summary = "아이디 찾기")
+    @CustomExceptionDescription(SwaggerResponseDescription.FIND_EMAIL_FAIL)
+    @PostMapping("find-email")
+    public ResponseEntity<BaseResponse<FindEmailResponse>> findEmail(@RequestBody @Valid FindEmailRequest findEmailRequest){
+        FindEmailResponse findEmailResponse = authService.findEmail(findEmailRequest);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.USER_EMAIL_FOUND, findEmailResponse));
     }
 
 }

--- a/src/main/java/com/blockguard/server/domain/auth/api/AuthApi.java
+++ b/src/main/java/com/blockguard/server/domain/auth/api/AuthApi.java
@@ -53,4 +53,12 @@ public class AuthApi {
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.USER_EMAIL_FOUND, findEmailResponse));
     }
 
+    @Operation(summary = "비밀번호 찾기", description = "이메일이 유효하면 해당 이메일로 임시 비밀번호를 발송합니다.")
+    @CustomExceptionDescription(SwaggerResponseDescription.FIND_PASSWORD_FAIL)
+    @PostMapping("find-password")
+    public ResponseEntity<BaseResponse<Void>> findPassword(@RequestBody @Valid FindPasswordRequest findPasswordRequest){
+        authService.sendTempPassword(findPasswordRequest);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.SEND_TEMP_PASSWORD_BY_EMAIL));
+    }
+
 }

--- a/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
+++ b/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
@@ -4,6 +4,7 @@ import com.blockguard.server.domain.auth.domain.JwtToken;
 import com.blockguard.server.domain.auth.infra.JwtTokenGenerator;
 import com.blockguard.server.domain.user.domain.User;
 import com.blockguard.server.domain.user.dto.request.FindEmailRequest;
+import com.blockguard.server.domain.user.dto.request.FindPasswordRequest;
 import com.blockguard.server.domain.user.dto.request.LoginRequest;
 import com.blockguard.server.domain.user.dao.UserRepository;
 import com.blockguard.server.domain.user.dto.request.RegisterRequest;
@@ -13,9 +14,16 @@ import com.blockguard.server.domain.user.dto.response.RegisterResponse;
 import com.blockguard.server.global.common.codes.ErrorCode;
 import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import lombok.AllArgsConstructor;
-import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -70,5 +78,61 @@ public class AuthService {
         return FindEmailResponse.builder()
                 .email(user.getEmail())
                 .build();
+    }
+
+    public void sendTempPassword(FindPasswordRequest findPasswordRequest) {
+        User user = userRepository.findByEmail(findPasswordRequest.getEmail())
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.EMAIL_NOT_FOUND));
+
+        String tempPassword = generateTempPwd(user);
+
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setTo(findPasswordRequest.getEmail());
+        msg.setSubject("[BLOCKGUARD] 임시 비밀번호 안내");
+        msg.setText("임시 비밀번호는 아래와 같습니다:\n\n" + tempPassword +
+                "\n\n로그인 후 반드시 비밀번호를 변경해주세요." +
+                "\n\n만약 비밀번호 재발급을 요청한 적이 없다면 반드시 고객센터로 문의해주십시오.");
+
+        new Thread(() -> mailSender.send(msg)).start();
+
+    }
+
+    private JavaMailSender mailSender;
+
+    private String generateTempPwd(User user) {
+        String tempPassword = generateTempPassword();
+
+        user.changePassword(passwordEncoder.encode(tempPassword));
+        userRepository.save(user);
+        return tempPassword;
+    }
+
+    private String generateTempPassword() {
+        String str = "abcdefghijklmnopqrstuvwxyz";
+        String digits = "0123456789";
+        String special = "!@#$%^&*()_-+<>?";
+
+        String all = str + digits + special;
+        StringBuilder password = new StringBuilder();
+
+        Random random = new SecureRandom();
+
+        password.append(str.charAt(random.nextInt(str.length())));
+        password.append(digits.charAt(random.nextInt(digits.length())));
+        password.append(special.charAt(random.nextInt(special.length())));
+
+        for (int i = 0; i < 7; i++) {
+            password.append(all.charAt(random.nextInt(all.length())));
+        }
+
+        List<Character> passwordChars = password.chars()
+                .mapToObj(c -> (char) c)
+                .collect(Collectors.toList());
+        Collections.shuffle(passwordChars);
+
+        StringBuilder finalPassword = new StringBuilder();
+        passwordChars.forEach(finalPassword::append);
+
+        return finalPassword.toString();
     }
 }

--- a/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
+++ b/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
@@ -3,9 +3,11 @@ package com.blockguard.server.domain.auth.application;
 import com.blockguard.server.domain.auth.domain.JwtToken;
 import com.blockguard.server.domain.auth.infra.JwtTokenGenerator;
 import com.blockguard.server.domain.user.domain.User;
+import com.blockguard.server.domain.user.dto.request.FindEmailRequest;
 import com.blockguard.server.domain.user.dto.request.LoginRequest;
 import com.blockguard.server.domain.user.dao.UserRepository;
 import com.blockguard.server.domain.user.dto.request.RegisterRequest;
+import com.blockguard.server.domain.user.dto.response.FindEmailResponse;
 import com.blockguard.server.domain.user.dto.response.LoginResponse;
 import com.blockguard.server.domain.user.dto.response.RegisterResponse;
 import com.blockguard.server.global.common.codes.ErrorCode;
@@ -45,9 +47,9 @@ public class AuthService {
 
     public LoginResponse login(LoginRequest loginRequest) {
         User user = userRepository.findByEmail(loginRequest.getEmail())
-                .orElseThrow(() ->  new BusinessExceptionHandler(ErrorCode.INVALID_EMAIL));
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.INVALID_EMAIL));
 
-        if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())){
+        if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
             throw new BusinessExceptionHandler(ErrorCode.INVALID_PASSWORD);
         }
 
@@ -58,5 +60,15 @@ public class AuthService {
                 .jwtToken(jwtToken)
                 .build();
 
+    }
+
+    public FindEmailResponse findEmail(FindEmailRequest findEmailRequest) {
+        User user = userRepository.findByNameAndPhoneNumberAndBirthDate(
+                        findEmailRequest.getName(), findEmailRequest.getPhoneNumber(), findEmailRequest.getBirthDate())
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.USER_INFO_NOT_FOUND));
+
+        return FindEmailResponse.builder()
+                .email(user.getEmail())
+                .build();
     }
 }

--- a/src/main/java/com/blockguard/server/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/blockguard/server/domain/user/dao/UserRepository.java
@@ -3,8 +3,11 @@ package com.blockguard.server.domain.user.dao;
 import com.blockguard.server.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByNameAndPhoneNumberAndBirthDate(String name, String phoneNumber, LocalDate birthDate);
 }

--- a/src/main/java/com/blockguard/server/domain/user/domain/User.java
+++ b/src/main/java/com/blockguard/server/domain/user/domain/User.java
@@ -67,4 +67,8 @@ public class User extends BaseEntity {
     public void markDeleted() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void changePassword(String tempPassword) {
+        this.password = tempPassword;
+    }
 }

--- a/src/main/java/com/blockguard/server/domain/user/dto/request/FindEmailRequest.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/request/FindEmailRequest.java
@@ -1,0 +1,28 @@
+package com.blockguard.server.domain.user.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class FindEmailRequest {
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$",
+            message = "phoneNumber must match 010-1234-5678 format")
+    private String phoneNumber;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd")
+    @Schema(description = "생년월일 yyyyMMdd", example = "20000101")
+    private LocalDate birthDate;
+
+}

--- a/src/main/java/com/blockguard/server/domain/user/dto/request/FindPasswordRequest.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/request/FindPasswordRequest.java
@@ -1,0 +1,15 @@
+package com.blockguard.server.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FindPasswordRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+}

--- a/src/main/java/com/blockguard/server/domain/user/dto/request/RegisterRequest.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/request/RegisterRequest.java
@@ -2,6 +2,7 @@ package com.blockguard.server.domain.user.dto.request;
 
 import com.blockguard.server.domain.user.domain.enums.Gender;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -25,6 +26,7 @@ public class RegisterRequest {
     private String password;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd")
+    @Schema(description = "생년월일 yyyyMMdd", example = "20000101")
     private LocalDate birthDate;
 
     private Gender gender;

--- a/src/main/java/com/blockguard/server/domain/user/dto/response/FindEmailResponse.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/response/FindEmailResponse.java
@@ -1,0 +1,14 @@
+package com.blockguard.server.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FindEmailResponse {
+    private String email;
+}

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -11,7 +11,9 @@ public enum ErrorCode {
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, 4001, "이미 가입된 이메일입니다."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, 4002, "존재하지 않는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 4003, "비밀번호가 일치하지 않습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 4004, "유효하지 않은 토큰입니다."),
+    USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, 4004, "일치하는 회원 정보가 없습니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, 4005, "일치하는 이메일 정보가 없습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 4010, "유효하지 않은 토큰입니다."),
 
     // 5000~ : server error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -10,7 +10,9 @@ public enum SuccessCode {
 
     OK(HttpStatus.OK, 2000, "OK"),
     USER_REGISTERED(HttpStatus.CREATED, 2001, "회원가입이 완료되었습니다."),
-    LOGIN_SUCCESS(HttpStatus.OK, 2002, "로그인 성공");
+    LOGIN_SUCCESS(HttpStatus.OK, 2002, "로그인에 성공하였습니다."),
+    USER_EMAIL_FOUND(HttpStatus.OK, 2003, "아이디 조회에 성공하였습니다."),
+    SEND_EMAIL(HttpStatus.OK, 2005, "임시 비밀번호를 메일로 전송하였습니다.ㄹㄹ");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -12,7 +12,7 @@ public enum SuccessCode {
     USER_REGISTERED(HttpStatus.CREATED, 2001, "회원가입이 완료되었습니다."),
     LOGIN_SUCCESS(HttpStatus.OK, 2002, "로그인에 성공하였습니다."),
     USER_EMAIL_FOUND(HttpStatus.OK, 2003, "아이디 조회에 성공하였습니다."),
-    SEND_EMAIL(HttpStatus.OK, 2005, "임시 비밀번호를 메일로 전송하였습니다.ㄹㄹ");
+    SEND_TEMP_PASSWORD_BY_EMAIL(HttpStatus.OK, 2005, "임시 비밀번호를 메일로 전송하였습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
@@ -15,7 +15,16 @@ public enum SwaggerResponseDescription {
     LOGIN_FAIL(new LinkedHashSet<>(Set.of(
             ErrorCode.INVALID_EMAIL,
             ErrorCode.INVALID_PASSWORD
+    ))),
+
+    FIND_EMAIL_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.USER_INFO_NOT_FOUND
+    ))),
+
+    FIND_PASSWORD_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.EMAIL_NOT_FOUND
     )));
+
 
     private final Set<ErrorCode> errorCodeList;
 


### PR DESCRIPTION
## 💻 Related Issue
closed #11 

<br/>

## 🚀 Work Description
- [x] 아이디 찾기 api
- [x] 비밀번호 찾기 api

- 아이디 찾기: 이름, 생년월일, 전화번호가 일치할 경우 가입했던 이메일(아이디)를 반환합니다. 이메일 마스킹 작업은 프론트선생님들께 말씀드릴 예정입니다.
- 비밀번호 찾기: 이메일 조회 후, 존재할 경우 해당 이메일로 임시 비밀번호를 발급합니다. 이때 임시 비밀번호는 가입 시 비밀번호 로직에 맞게 생성하도록 하였습니다.

<img width="1912" height="1340" alt="image" src="https://github.com/user-attachments/assets/ddf64aeb-07e6-47f0-be55-8293652a05cd" />
: 기존 비밀번호로 로그인 시 -> 오류
<img width="1986" height="1286" alt="image" src="https://github.com/user-attachments/assets/3bd6efcc-e509-4dfe-a9a2-cf4efa26e6dd" />
: 재발급된 비밀번호로 로그인 시 -> 정상

<img width="1690" height="734" alt="image" src="https://github.com/user-attachments/assets/11b4cf21-0761-4ea4-b4b7-a9cb918e2457" />
다음과 같이 메일로 임시 비밀번호가 발급됩니다.

<br/>

## 🙇🏻‍♀️ To Reviewer
1. 비밀번호 재발급 보안을 강화해야할 것 같습니다. 다른 사람이 자신의 이메일이 아닌 다른 이메일을 입력했는데 해당 이메일이 존재할 경우, 보안 상 문제 및 사고가 발생할 수 있어 다른 정보도 확인하는 등의 로직을 추가해야할 것 같습니다.
2. 구글 이메일 발송을 위해 blockguard.official@gmail.com 이라는 구글 이메일을 생성하였습니다. aws 서버 생성할 때 만든 구글 이메일을 사용하려했는데 chaeyuuuu.. 로 해버려서 ㅠㅠ... 다시 하나 만들었습니다.

확인 후 머지해도 되면 이후 작업 수행하겠습니다.!
<br/>

## ➕ Next
- [ ] 비밀번호 변경 api
- [ ] 회원탈퇴 api
- [ ] 마이페이지 조회 api
- [ ] 회원정보 수정 api

 <br/>
