### PR TITLE
[Feat] User api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation(platform("software.amazon.awssdk:bom:2.31.40"))
+	implementation 'software.amazon.awssdk:s3'
+	implementation 'software.amazon.awssdk:auth'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
+++ b/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
@@ -7,6 +7,8 @@ import com.blockguard.server.domain.user.dto.response.MyPageResponse;
 import com.blockguard.server.global.common.codes.SuccessCode;
 import com.blockguard.server.global.common.response.BaseResponse;
 import com.blockguard.server.global.config.resolver.CurrentUser;
+import com.blockguard.server.global.config.swagger.CustomExceptionDescription;
+import com.blockguard.server.global.config.swagger.SwaggerResponseDescription;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
@@ -22,12 +24,13 @@ public class UserApi {
     @GetMapping("/me")
     @Operation(summary = "마이페이지 조회")
     public BaseResponse<MyPageResponse> getMyPageInfo(@Parameter(hidden = true) @CurrentUser User user){
-        MyPageResponse myPageResponse = MyPageResponse.from(user);
+        MyPageResponse myPageResponse = userService.getMyPageInfo(user);
         return BaseResponse.of(SuccessCode.GET_MY_PAGE_SUCCESS, myPageResponse);
     }
 
     @PutMapping(value = "/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "회원 정보 수정", description = "아이디를 제외하고 수정가능합니다.")
+    @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_MY_PAGE_INFO_FAIL)
+    @Operation(summary = "회원 정보 수정", description = "아이디를 제외하고 수정가능합니다. 생년월일 형식은 'yyyyMMDD'로 입력해야합니다.")
     public BaseResponse<Void> updateUserInfo(@Parameter(hidden = true) @CurrentUser User user,
                                              @ModelAttribute UpdateUserInfo updateUserInfo){
         userService.updateUserInfo(user.getId(), updateUserInfo);

--- a/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
+++ b/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
@@ -9,6 +9,7 @@ import com.blockguard.server.global.config.resolver.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,6 +25,13 @@ public class UserApi {
     public BaseResponse<MyPageResponse> getMyPageInfo(@Parameter(hidden = true) @CurrentUser User user){
         MyPageResponse myPageResponse = MyPageResponse.from(user);
         return BaseResponse.of(SuccessCode.GET_MY_PAGE_SUCCESS, myPageResponse);
+    }
+
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴")
+    public BaseResponse<Void> withdraw(@Parameter(hidden = true) @CurrentUser User user){
+        userService.withdraw(user.getId());
+        return BaseResponse.of(SuccessCode.WITHDRAW_SUCCESS);
     }
 
 }

--- a/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
+++ b/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
@@ -2,6 +2,7 @@ package com.blockguard.server.domain.user.api;
 
 import com.blockguard.server.domain.user.application.UserService;
 import com.blockguard.server.domain.user.domain.User;
+import com.blockguard.server.domain.user.dto.request.UpdatePasswordRequest;
 import com.blockguard.server.domain.user.dto.request.UpdateUserInfo;
 import com.blockguard.server.domain.user.dto.response.MyPageResponse;
 import com.blockguard.server.global.common.codes.SuccessCode;
@@ -35,6 +36,16 @@ public class UserApi {
                                              @ModelAttribute UpdateUserInfo updateUserInfo){
         userService.updateUserInfo(user.getId(), updateUserInfo);
         return BaseResponse.of(SuccessCode.UPDATE_USER_INFO_SUCCESS);
+
+    }
+
+    @PutMapping(value = "/me/password")
+    @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_MY_PAGE_INFO_FAIL)
+    @Operation(summary = "비밀번호 변경", description = "현재 비밀번호를 확인하고, 새 비밀번호로 변경합니다.")
+    public BaseResponse<Void> updatePassword(@Parameter(hidden = true) @CurrentUser User user,
+    @RequestBody UpdatePasswordRequest updatePasswordRequest){
+       userService.updatePassword(user, updatePasswordRequest);
+       return BaseResponse.of(SuccessCode.UPDATE_PASSWORD_SUCCESS);
 
     }
 

--- a/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
+++ b/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
@@ -1,0 +1,29 @@
+package com.blockguard.server.domain.user.api;
+
+import com.blockguard.server.domain.user.application.UserService;
+import com.blockguard.server.domain.user.domain.User;
+import com.blockguard.server.domain.user.dto.response.MyPageResponse;
+import com.blockguard.server.global.common.codes.SuccessCode;
+import com.blockguard.server.global.common.response.BaseResponse;
+import com.blockguard.server.global.config.resolver.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/users")
+public class UserApi {
+    private final UserService userService;
+
+    @GetMapping("/me")
+    @Operation(summary = "마이페이지 조회")
+    public BaseResponse<MyPageResponse> getMyPageInfo(@Parameter(hidden = true) @CurrentUser User user){
+        MyPageResponse myPageResponse = MyPageResponse.from(user);
+        return BaseResponse.of(SuccessCode.GET_MY_PAGE_SUCCESS, myPageResponse);
+    }
+
+}

--- a/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
+++ b/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
@@ -2,6 +2,7 @@ package com.blockguard.server.domain.user.api;
 
 import com.blockguard.server.domain.user.application.UserService;
 import com.blockguard.server.domain.user.domain.User;
+import com.blockguard.server.domain.user.dto.request.UpdateUserInfo;
 import com.blockguard.server.domain.user.dto.response.MyPageResponse;
 import com.blockguard.server.global.common.codes.SuccessCode;
 import com.blockguard.server.global.common.response.BaseResponse;
@@ -9,10 +10,8 @@ import com.blockguard.server.global.config.resolver.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @AllArgsConstructor
@@ -27,11 +26,22 @@ public class UserApi {
         return BaseResponse.of(SuccessCode.GET_MY_PAGE_SUCCESS, myPageResponse);
     }
 
+    @PutMapping(value = "/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "회원 정보 수정", description = "아이디를 제외하고 수정가능합니다.")
+    public BaseResponse<Void> updateUserInfo(@Parameter(hidden = true) @CurrentUser User user,
+                                             @ModelAttribute UpdateUserInfo updateUserInfo){
+        userService.updateUserInfo(user.getId(), updateUserInfo);
+        return BaseResponse.of(SuccessCode.UPDATE_USER_INFO_SUCCESS);
+
+    }
+
     @DeleteMapping("/withdraw")
     @Operation(summary = "회원 탈퇴")
     public BaseResponse<Void> withdraw(@Parameter(hidden = true) @CurrentUser User user){
         userService.withdraw(user.getId());
         return BaseResponse.of(SuccessCode.WITHDRAW_SUCCESS);
     }
+
+
 
 }

--- a/src/main/java/com/blockguard/server/domain/user/application/UserService.java
+++ b/src/main/java/com/blockguard/server/domain/user/application/UserService.java
@@ -3,21 +3,28 @@ package com.blockguard.server.domain.user.application;
 import com.blockguard.server.domain.user.dao.UserRepository;
 import com.blockguard.server.domain.user.domain.User;
 import com.blockguard.server.domain.user.dto.request.UpdateUserInfo;
+import com.blockguard.server.domain.user.dto.response.MyPageResponse;
 import com.blockguard.server.global.common.codes.ErrorCode;
+import com.blockguard.server.global.config.S3.S3Service;
 import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
 @Service
 @AllArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final S3Service s3Service;
 
     @Transactional
     public void withdraw(Long id) {
         User user = userRepository.findById(id)
-                .orElseThrow(()-> new BusinessExceptionHandler(ErrorCode.INVALID_USER));
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.INVALID_USER));
 
         user.markDeleted();
     }
@@ -25,10 +32,29 @@ public class UserService {
     @Transactional
     public void updateUserInfo(Long id, UpdateUserInfo updateUserInfo) {
         User user = userRepository.findById(id)
-                .orElseThrow(()-> new BusinessExceptionHandler(ErrorCode.INVALID_USER));
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.INVALID_USER));
 
-        if(updateUserInfo.getName()!=null) user.updateName(updateUserInfo.getName());
-        if(updateUserInfo.getPhoneNumber()!=null) user.updatePhoneNumber(updateUserInfo.getPhoneNumber());
-        // if(updateUserInfo.getProfileImage()!=null) user.updateProfileImageKey(updateUserInfo.getProfileImage());
+        if (updateUserInfo.getName() != null) user.updateName(updateUserInfo.getName());
+
+        if (updateUserInfo.getPhoneNumber() != null) user.updatePhoneNumber(updateUserInfo.getPhoneNumber());
+
+        if (updateUserInfo.getBirthDate() != null) {
+            try {
+                LocalDate parsedBirthDate = LocalDate.parse(updateUserInfo.getBirthDate(), DateTimeFormatter.BASIC_ISO_DATE);
+                user.updateBirthDate(parsedBirthDate);
+            } catch (DateTimeParseException e){
+                throw new BusinessExceptionHandler(ErrorCode.INVALID_DATE_FORMAT);
+            }
+        }
+        if (updateUserInfo.getProfileImage() != null && !updateUserInfo.getProfileImage().isEmpty()) {
+            String imageKey = s3Service.upload(updateUserInfo.getProfileImage(), "profiles");
+            user.updateProfileImageKey(imageKey);
+        }
+    }
+
+    public MyPageResponse getMyPageInfo(User user) {
+        String profileImageUrl = (user.getProfileImageKey() != null) ?
+                s3Service.getPublicUrl(user.getProfileImageKey()) : null;
+        return MyPageResponse.from(user, profileImageUrl);
     }
 }

--- a/src/main/java/com/blockguard/server/domain/user/application/UserService.java
+++ b/src/main/java/com/blockguard/server/domain/user/application/UserService.java
@@ -2,6 +2,7 @@ package com.blockguard.server.domain.user.application;
 
 import com.blockguard.server.domain.user.dao.UserRepository;
 import com.blockguard.server.domain.user.domain.User;
+import com.blockguard.server.domain.user.dto.request.UpdateUserInfo;
 import com.blockguard.server.global.common.codes.ErrorCode;
 import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import lombok.AllArgsConstructor;
@@ -19,5 +20,15 @@ public class UserService {
                 .orElseThrow(()-> new BusinessExceptionHandler(ErrorCode.INVALID_USER));
 
         user.markDeleted();
+    }
+
+    @Transactional
+    public void updateUserInfo(Long id, UpdateUserInfo updateUserInfo) {
+        User user = userRepository.findById(id)
+                .orElseThrow(()-> new BusinessExceptionHandler(ErrorCode.INVALID_USER));
+
+        if(updateUserInfo.getName()!=null) user.updateName(updateUserInfo.getName());
+        if(updateUserInfo.getPhoneNumber()!=null) user.updatePhoneNumber(updateUserInfo.getPhoneNumber());
+        // if(updateUserInfo.getProfileImage()!=null) user.updateProfileImageKey(updateUserInfo.getProfileImage());
     }
 }

--- a/src/main/java/com/blockguard/server/domain/user/application/UserService.java
+++ b/src/main/java/com/blockguard/server/domain/user/application/UserService.java
@@ -1,12 +1,23 @@
 package com.blockguard.server.domain.user.application;
 
 import com.blockguard.server.domain.user.dao.UserRepository;
+import com.blockguard.server.domain.user.domain.User;
+import com.blockguard.server.global.common.codes.ErrorCode;
+import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
 
+    @Transactional
+    public void withdraw(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(()-> new BusinessExceptionHandler(ErrorCode.INVALID_USER));
+
+        user.markDeleted();
+    }
 }

--- a/src/main/java/com/blockguard/server/domain/user/application/UserService.java
+++ b/src/main/java/com/blockguard/server/domain/user/application/UserService.java
@@ -1,0 +1,12 @@
+package com.blockguard.server.domain.user.application;
+
+import com.blockguard.server.domain.user.dao.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+}

--- a/src/main/java/com/blockguard/server/domain/user/domain/User.java
+++ b/src/main/java/com/blockguard/server/domain/user/domain/User.java
@@ -8,6 +8,7 @@ import com.blockguard.server.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -70,5 +71,21 @@ public class User extends BaseEntity {
 
     public void changePassword(String tempPassword) {
         this.password = tempPassword;
+    }
+
+    public void updateName(String updateName) {
+        this.name = updateName;
+    }
+
+    public void updatePhoneNumber(String updatePhoneNumber){
+        this.phoneNumber = updatePhoneNumber;
+    }
+
+    public void updateProfileImageKey(String updateProfileImageKey) {
+        this.profileImageKey = updateProfileImageKey;
+    }
+
+    public void updateBirthDate(LocalDate updateBirthDate) {
+        this.birthDate = updateBirthDate;
     }
 }

--- a/src/main/java/com/blockguard/server/domain/user/domain/User.java
+++ b/src/main/java/com/blockguard/server/domain/user/domain/User.java
@@ -67,4 +67,16 @@ public class User extends BaseEntity {
     public void markDeleted() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void updateName(String updateName) {
+        this.name = updateName;
+    }
+
+    public void updatePhoneNumber(String updatePhoneNumber) {
+        this.phoneNumber = updatePhoneNumber;
+    }
+
+    public void updateProfileImageKey(String updateProfileImageKey){
+        this.profileImageKey = updateProfileImageKey;
+    }
 }

--- a/src/main/java/com/blockguard/server/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/request/LoginRequest.java
@@ -1,5 +1,6 @@
 package com.blockguard.server.domain.user.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,8 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class LoginRequest {
+    @NotBlank
     private String email;
+    @NotBlank
     private String password;
 }

--- a/src/main/java/com/blockguard/server/domain/user/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/request/UpdatePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.blockguard.server.domain.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UpdatePasswordRequest {
+    private String currentPwd;
+    private String newPwd;
+}

--- a/src/main/java/com/blockguard/server/domain/user/dto/request/UpdateUserInfo.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/request/UpdateUserInfo.java
@@ -1,0 +1,17 @@
+package com.blockguard.server.domain.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UpdateUserInfo {
+    private String name;
+    private String birthDate; //yyyyMMDD
+    private String phoneNumber;
+    private MultipartFile profileImage;
+
+}

--- a/src/main/java/com/blockguard/server/domain/user/dto/response/MyPageResponse.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/response/MyPageResponse.java
@@ -1,0 +1,29 @@
+package com.blockguard.server.domain.user.dto.response;
+
+import com.blockguard.server.domain.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MyPageResponse {
+    private String email;
+    private String name;
+    private String birthDate;
+    private String phoneNumber;
+    private String profileImageUrl;
+
+    public static MyPageResponse from(User user) {
+        return MyPageResponse.builder()
+                .email(user.getEmail())
+                .name(user.getName())
+                .birthDate(user.getBirthDate().format(DateTimeFormatter.ofPattern("yyyyMMdd")))
+                .phoneNumber(user.getPhoneNumber())
+                .profileImageUrl(user.getProfileImageKey())
+                .build();
+    }
+}

--- a/src/main/java/com/blockguard/server/domain/user/dto/response/MyPageResponse.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/response/MyPageResponse.java
@@ -17,7 +17,7 @@ public class MyPageResponse {
     private String phoneNumber;
     private String profileImageUrl;
 
-    public static MyPageResponse from(User user) {
+    public static MyPageResponse from(User user, String profileImageUrl) {
         return MyPageResponse.builder()
                 .email(user.getEmail())
                 .name(user.getName())

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode {
     USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, 4004, "일치하는 회원 정보가 없습니다."),
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, 4005, "일치하는 이메일 정보가 없습니다."),
     INVALID_USER(HttpStatus.NOT_FOUND, 4006, "존재하지 않는 회원입니다."),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, 4007, "생년월일 형식이 올바르지 않습니다. yyyyMMDD 형식으로 입력해주십시오."),
+    INVALID_PHONE_NUMBER_FORMAT(HttpStatus.BAD_REQUEST, 4008, "전화번호 형식이 올바르지 않습니다. 010-1234-5678 형식으로 입력해주십시오."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 4010, "유효하지 않은 토큰입니다."),
 
     // 5000~ : server error

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, 4002, "존재하지 않는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 4003, "비밀번호가 일치하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 4004, "유효하지 않은 토큰입니다."),
+    INVALID_USER(HttpStatus.UNAUTHORIZED, 4005, "존재하지 않는 사용자입니다."),
 
     // 5000~ : server error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 4003, "비밀번호가 일치하지 않습니다."),
     USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, 4004, "일치하는 회원 정보가 없습니다."),
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, 4005, "일치하는 이메일 정보가 없습니다."),
+    INVALID_USER(HttpStatus.NOT_FOUND, 4006, "존재하지 않는 회원입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 4010, "유효하지 않은 토큰입니다."),
 
     // 5000~ : server error

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     INVALID_USER(HttpStatus.NOT_FOUND, 4006, "존재하지 않는 회원입니다."),
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, 4007, "생년월일 형식이 올바르지 않습니다. yyyyMMDD 형식으로 입력해주십시오."),
     INVALID_PHONE_NUMBER_FORMAT(HttpStatus.BAD_REQUEST, 4008, "전화번호 형식이 올바르지 않습니다. 010-1234-5678 형식으로 입력해주십시오."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, 4009, "현재 비밀번호 값이 일치하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 4010, "유효하지 않은 토큰입니다."),
 
     // 5000~ : server error

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -15,7 +15,8 @@ public enum SuccessCode {
     SEND_TEMP_PASSWORD_BY_EMAIL(HttpStatus.OK, 2004, "임시 비밀번호를 메일로 전송하였습니다."),
     GET_MY_PAGE_SUCCESS(HttpStatus.OK, 2005, "마이페이지 조회에 성공하였습니다."),
     UPDATE_USER_INFO_SUCCESS(HttpStatus.OK, 2006, "회원 정보를 수정하였습니다."),
-    WITHDRAW_SUCCESS(HttpStatus.OK, 2007, "회원 탈퇴가 성공하였습니다.");
+    WITHDRAW_SUCCESS(HttpStatus.OK, 2007, "회원 탈퇴가 성공하였습니다."),
+    UPDATE_PASSWORD_SUCCESS(HttpStatus.OK,2008,"비밀번호 변경에 성공하였습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -11,7 +11,8 @@ public enum SuccessCode {
     OK(HttpStatus.OK, 2000, "OK"),
     USER_REGISTERED(HttpStatus.CREATED, 2001, "회원가입이 완료되었습니다."),
     LOGIN_SUCCESS(HttpStatus.OK, 2002, "로그인 성공"),
-    GET_MY_PAGE_SUCCESS(HttpStatus.OK, 2004, "마이페이지 조회에 성공하였습니다.");
+    GET_MY_PAGE_SUCCESS(HttpStatus.OK, 2004, "마이페이지 조회에 성공하였습니다."),
+    WITHDRAW_SUCCESS(HttpStatus.OK, 2005, "회원 탈퇴에 성공하였습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -12,7 +12,10 @@ public enum SuccessCode {
     USER_REGISTERED(HttpStatus.CREATED, 2001, "회원가입이 완료되었습니다."),
     LOGIN_SUCCESS(HttpStatus.OK, 2002, "로그인에 성공하였습니다."),
     USER_EMAIL_FOUND(HttpStatus.OK, 2003, "아이디 조회에 성공하였습니다."),
-    SEND_TEMP_PASSWORD_BY_EMAIL(HttpStatus.OK, 2005, "임시 비밀번호를 메일로 전송하였습니다.");
+    SEND_TEMP_PASSWORD_BY_EMAIL(HttpStatus.OK, 2004, "임시 비밀번호를 메일로 전송하였습니다."),
+    GET_MY_PAGE_SUCCESS(HttpStatus.OK, 2005, "마이페이지 조회에 성공하였습니다."),
+    UPDATE_USER_INFO_SUCCESS(HttpStatus.OK, 2006, "회원 정보를 수정하였습니다."),
+    WITHDRAW_SUCCESS(HttpStatus.OK, 2007, "회원 탈퇴가 성공하였습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -10,7 +10,8 @@ public enum SuccessCode {
 
     OK(HttpStatus.OK, 2000, "OK"),
     USER_REGISTERED(HttpStatus.CREATED, 2001, "회원가입이 완료되었습니다."),
-    LOGIN_SUCCESS(HttpStatus.OK, 2002, "로그인 성공");
+    LOGIN_SUCCESS(HttpStatus.OK, 2002, "로그인 성공"),
+    GET_MY_PAGE_SUCCESS(HttpStatus.OK, 2004, "마이페이지 조회에 성공하였습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -12,7 +12,8 @@ public enum SuccessCode {
     USER_REGISTERED(HttpStatus.CREATED, 2001, "회원가입이 완료되었습니다."),
     LOGIN_SUCCESS(HttpStatus.OK, 2002, "로그인 성공"),
     GET_MY_PAGE_SUCCESS(HttpStatus.OK, 2004, "마이페이지 조회에 성공하였습니다."),
-    WITHDRAW_SUCCESS(HttpStatus.OK, 2005, "회원 탈퇴에 성공하였습니다.");
+    WITHDRAW_SUCCESS(HttpStatus.OK, 2005, "회원 탈퇴에 성공하였습니다."),
+    UPDATE_USER_INFO_SUCCESS(HttpStatus.OK, 2006, "회원 정보 업데이트에 성공하였습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/config/S3/S3Config.java
+++ b/src/main/java/com/blockguard/server/global/config/S3/S3Config.java
@@ -1,0 +1,32 @@
+package com.blockguard.server.global.config.S3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.region}")
+    private String region;
+
+    @Value("${cloud.aws.s3.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.s3.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/blockguard/server/global/config/S3/S3Service.java
+++ b/src/main/java/com/blockguard/server/global/config/S3/S3Service.java
@@ -1,0 +1,57 @@
+package com.blockguard.server.global.config.S3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket-name}")
+    private String bucket;
+
+    public String upload(MultipartFile file, String dir) {
+
+        String ext = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        String key = dir + "/" + UUID.randomUUID() + "." + ext;
+
+        try (InputStream is = file.getInputStream()) {
+            PutObjectRequest req = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(req, RequestBody.fromInputStream(is, file.getSize()));
+        } catch (IOException e) {
+            throw new RuntimeException("S3 업로드 실패", e);
+        }
+
+        return getPublicUrl(key);
+    }
+
+    public void delete(String key) {
+        DeleteObjectRequest req = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+        s3Client.deleteObject(req);
+    }
+
+    public String getPublicUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                bucket, s3Client.serviceClientConfiguration().region(), key);
+    }
+}

--- a/src/main/java/com/blockguard/server/global/config/WebMvcConfig.java
+++ b/src/main/java/com/blockguard/server/global/config/WebMvcConfig.java
@@ -1,12 +1,19 @@
 package com.blockguard.server.global.config;
 
+import com.blockguard.server.global.config.resolver.CurrentUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
     private final long MAX_AGE_SECS = 3600;
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -15,6 +22,11 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(MAX_AGE_SECS);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
     }
 
 }

--- a/src/main/java/com/blockguard/server/global/config/resolver/CurrentUser.java
+++ b/src/main/java/com/blockguard/server/global/config/resolver/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.blockguard.server.global.config.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/src/main/java/com/blockguard/server/global/config/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/blockguard/server/global/config/resolver/CurrentUserArgumentResolver.java
@@ -1,0 +1,41 @@
+package com.blockguard.server.global.config.resolver;
+
+import com.blockguard.server.domain.user.domain.User;
+import com.blockguard.server.global.common.codes.ErrorCode;
+import com.blockguard.server.global.exception.BusinessExceptionHandler;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // @CurrentUser가 붙어있고 타입이 User일 경우에만 처리
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+
+        // 현재 로그인된 사용자의 Authentication 정보 꺼내옴
+        // 로그인되어있다면 getPrincipal() 안에 User 객체 존재 -> 그대로 리턴해 컨트롤러에 주입
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null ||!(authentication.getPrincipal() instanceof User)){
+            throw new BusinessExceptionHandler(ErrorCode.INVALID_TOKEN);
+        }
+
+        return authentication.getPrincipal();
+    }
+}

--- a/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
@@ -21,9 +21,15 @@ public enum SwaggerResponseDescription {
             ErrorCode.USER_INFO_NOT_FOUND
     ))),
 
+    UPDATE_MY_PAGE_INFO_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.INVALID_DATE_FORMAT
+    ))),
+
     FIND_PASSWORD_FAIL(new LinkedHashSet<>(Set.of(
             ErrorCode.EMAIL_NOT_FOUND
     )));
+
+
 
 
     private final Set<ErrorCode> errorCodeList;


### PR DESCRIPTION
## 💻 Related Issue
closed #16 

<br/>

## 🚀 Work Description
- [x] S3 Config 설정 완료
- [x] 마이페이지 조회 api 완료
- [x] 비밀번호 변경 api 완료
- [x] 회원정보 수정 api 완료
- [x] 회원탈퇴 api 완료

- S3에 이미지 파일 업로드 성공 확인하였습니다.
<img width="1245" height="320" alt="image" src="https://github.com/user-attachments/assets/3f86fa51-29e8-4f89-a64c-cbc271503d97" />

- 비밀번호 변경 api 완료하였습니다. 현재 비밀번호 입력값이 실제 db에 저장된 비밀번호와 일치하지 않을 경우 에러발생합니다.
<img width="1270" height="714" alt="image" src="https://github.com/user-attachments/assets/684a18ae-aec8-42fc-b273-a85636634d90" />
: 비밀번호 변경 (형식은 프론트에서 체크할거라 우선 임의로 했습니다.)
<img width="1296" height="1240" alt="image" src="https://github.com/user-attachments/assets/c28bb318-3aa9-4ee3-94a9-610226f3d53a" />
: 기존 비밀번호로 입력 시, 로그인 실패
<img width="1290" height="1234" alt="image" src="https://github.com/user-attachments/assets/d578440b-3645-4920-9659-6ade128d682c" />
: 비밀번호 변경 후 새로운 비밀번호로 입력 시, 로그인 성공

- 마이페이지 조회는 다음과 같이 응답이 옵니다.
<img width="2166" height="1102" alt="image" src="https://github.com/user-attachments/assets/2214fb94-e1e7-4c82-a984-2bb79fda4bd6" />

- 회원정보 수정 api는 multipart로 요청해야합니다.
<img width="2184" height="1284" alt="image" src="https://github.com/user-attachments/assets/e78ba397-22df-441a-bdec-f265d68f988f" />
<br/>

## 🙇🏻‍♀️ To Reviewer
- S3Config, S3Service 파일 추가하였습니다!
- 저희가 생년월일 입력을 yyyyMMDD로 받는데 스웨거에서는 계속 yyyy-MM-DD 형식으로 request 예시가 뜨더라고요 ㅠ ㅠ 혹시 해결방법 아시나요?
- 추가로, jwt 토큰 검사를 `@CurrentUser` 라는 어노테이션을 생성하여 작업하였습니다. 더 좋은 방법 있다면 훈수 부탁드립니다! 
- 아직 세세한 입력 오류를 놓친 부분이 있는 것 같습니다. 추후 리팩토링 작업에서 해보도록 하겠습니다.
<br/>

## ➕ Next
- 지난 pr에 달린 리팩토링사항들 위주로 작업하겠습니다. ex) 임시 비밀번호, 메일전송 스레드
 <br/>
