### PR TITLE
[Fix] 이미지 업로드 용량 초과 예외 처리 & 보호자 이름 유니크 제약 및 예외 처리

### DIFF
--- a/src/main/java/com/blockguard/server/domain/guardian/application/GuardianService.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/application/GuardianService.java
@@ -34,7 +34,7 @@ public class GuardianService {
 
     @Transactional
     public GuardianResponse createGuardian(User user, CreateGuardianRequest request) {
-        if (guardianRepository.existsByUserAndName(user, request.getName())) {
+        if (guardianRepository.existsByUserAndNameAndDeletedAtIsNull(user, request.getName())) {
             throw new BusinessExceptionHandler(ErrorCode.DUPLICATE_GUARDIAN_NAME);
         }
 
@@ -59,7 +59,7 @@ public class GuardianService {
                 .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.GUARDIAN_NOT_FOUND));
 
         if (!guardian.getName().equals(request.getName()) &&
-                guardianRepository.existsByUserAndName(user, request.getName())) {
+                guardianRepository.existsByUserAndNameAndDeletedAtIsNull(user, request.getName())) {
             throw new BusinessExceptionHandler(ErrorCode.DUPLICATE_GUARDIAN_NAME);
         }
 

--- a/src/main/java/com/blockguard/server/domain/guardian/application/GuardianService.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/application/GuardianService.java
@@ -58,7 +58,8 @@ public class GuardianService {
         Guardian guardian = guardianRepository.findByIdAndUser(guardianId, user)
                 .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.GUARDIAN_NOT_FOUND));
 
-        if (guardianRepository.existsByUserAndName(user, request.getName())) {
+        if (!guardian.getName().equals(request.getName()) &&
+                guardianRepository.existsByUserAndName(user, request.getName())) {
             throw new BusinessExceptionHandler(ErrorCode.DUPLICATE_GUARDIAN_NAME);
         }
 

--- a/src/main/java/com/blockguard/server/domain/guardian/application/GuardianService.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/application/GuardianService.java
@@ -34,6 +34,10 @@ public class GuardianService {
 
     @Transactional
     public GuardianResponse createGuardian(User user, CreateGuardianRequest request) {
+        if (guardianRepository.existsByUserAndName(user, request.getName())) {
+            throw new BusinessExceptionHandler(ErrorCode.DUPLICATE_GUARDIAN_NAME);
+        }
+
         String key = (request.getProfileImage() != null && !request.getProfileImage().isEmpty())
                 ? s3Service.upload(request.getProfileImage(), "guardians"): null;
 
@@ -53,6 +57,10 @@ public class GuardianService {
     public GuardianResponse updateGuardian(User user, Long guardianId, CreateGuardianRequest request) {
         Guardian guardian = guardianRepository.findByIdAndUser(guardianId, user)
                 .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.GUARDIAN_NOT_FOUND));
+
+        if (guardianRepository.existsByUserAndName(user, request.getName())) {
+            throw new BusinessExceptionHandler(ErrorCode.DUPLICATE_GUARDIAN_NAME);
+        }
 
         String key = null;
         if (request.getProfileImage() != null && !request.getProfileImage().isEmpty()){

--- a/src/main/java/com/blockguard/server/domain/guardian/dao/GuardianRepository.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/dao/GuardianRepository.java
@@ -23,5 +23,5 @@ public interface GuardianRepository extends JpaRepository<Guardian, Long> {
   """)
     void clearPrimaryFlagsByUser(User user);
 
-    boolean existsByUserAndName(User user, String name);
+    boolean existsByUserAndNameAndDeletedAtIsNull(User user, String name);
 }

--- a/src/main/java/com/blockguard/server/domain/guardian/dao/GuardianRepository.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/dao/GuardianRepository.java
@@ -22,4 +22,6 @@ public interface GuardianRepository extends JpaRepository<Guardian, Long> {
         AND g.isPrimary = true
   """)
     void clearPrimaryFlagsByUser(User user);
+
+    boolean existsByUserAndName(User user, String name);
 }

--- a/src/main/java/com/blockguard/server/domain/guardian/domain/Guardian.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/domain/Guardian.java
@@ -14,12 +14,7 @@ import java.time.LocalDateTime;
 @Builder
 @Getter
 @SQLRestriction("deleted_at IS NULL")
-@Table(
-        name = "guardians",
-        uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "name"})
-        }
-)
+@Table(name = "guardians")
 public class Guardian extends BaseEntity {
 
     @Id

--- a/src/main/java/com/blockguard/server/domain/guardian/domain/Guardian.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/domain/Guardian.java
@@ -14,7 +14,12 @@ import java.time.LocalDateTime;
 @Builder
 @Getter
 @SQLRestriction("deleted_at IS NULL")
-@Table(name = "guardians")
+@Table(
+        name = "guardians",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "name"})
+        }
+)
 public class Guardian extends BaseEntity {
 
     @Id

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 4020, "유효하지 않은 토큰입니다."),
     FILE_NAME_NOT_FOUND(HttpStatus.NOT_FOUND, 4021, "파일명이 없습니다."),
     INVALID_DIRECTORY_ROUTE(HttpStatus.NOT_FOUND, 4022, "잘못된 디렉토리 경로입니다."),
-    FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, 4023, "프로필 파일 최대 허용 용량(10MB)을 초과했습니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, 4023, "프로필 파일 최대 허용 용량(5MB)을 초과했습니다."),
+    DUPLICATE_GUARDIAN_NAME(HttpStatus.BAD_REQUEST, 4024, "이미 등록된 보호자 이름입니다."),
 
     // 5000~ : server error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 4020, "유효하지 않은 토큰입니다."),
     FILE_NAME_NOT_FOUND(HttpStatus.NOT_FOUND, 4021, "파일명이 없습니다."),
     INVALID_DIRECTORY_ROUTE(HttpStatus.NOT_FOUND, 4022, "잘못된 디렉토리 경로입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, 4023, "프로필 파일 최대 허용 용량(10MB)을 초과했습니다."),
 
     // 5000~ : server error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
@@ -22,7 +22,11 @@ public enum SwaggerResponseDescription {
     ))),
 
     UPDATE_MY_PAGE_INFO_FAIL(new LinkedHashSet<>(Set.of(
-            ErrorCode.INVALID_DATE_FORMAT
+            ErrorCode.INVALID_PHONE_NUMBER_FORMAT,
+            ErrorCode.INVALID_PROFILE_IMAGE,
+            ErrorCode.FILE_NAME_NOT_FOUND,
+            ErrorCode.INVALID_DIRECTORY_ROUTE,
+            ErrorCode.FILE_SIZE_EXCEEDED
     ))),
 
     FIND_PASSWORD_FAIL(new LinkedHashSet<>(Set.of(
@@ -37,7 +41,9 @@ public enum SwaggerResponseDescription {
             ErrorCode.INVALID_PHONE_NUMBER_FORMAT,
             ErrorCode.INVALID_PROFILE_IMAGE,
             ErrorCode.FILE_NAME_NOT_FOUND,
-            ErrorCode.INVALID_DIRECTORY_ROUTE
+            ErrorCode.INVALID_DIRECTORY_ROUTE,
+            ErrorCode.FILE_SIZE_EXCEEDED,
+            ErrorCode.DUPLICATE_GUARDIAN_NAME
     ))),
 
     UPDATE_GUARDIAN_FAIL(new LinkedHashSet<>(Set.of(
@@ -45,7 +51,9 @@ public enum SwaggerResponseDescription {
             ErrorCode.INVALID_PROFILE_IMAGE,
             ErrorCode.GUARDIAN_NOT_FOUND,
             ErrorCode.FILE_NAME_NOT_FOUND,
-            ErrorCode.INVALID_DIRECTORY_ROUTE
+            ErrorCode.INVALID_DIRECTORY_ROUTE,
+            ErrorCode.FILE_SIZE_EXCEEDED,
+            ErrorCode.DUPLICATE_GUARDIAN_NAME
     ))),
 
     UPDATE_GUARDIAN_PRIMARY_FAIL(new LinkedHashSet<>(Set.of(

--- a/src/main/java/com/blockguard/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/blockguard/server/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
 @Slf4j
@@ -18,6 +19,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected ResponseEntity<ErrorResponse> handleMaxUploadSize(MaxUploadSizeExceededException maxUploadSizeExceededException) {
+        log.error("[MaxUploadSizeExceeded] message: {}", maxUploadSizeExceededException.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.FILE_SIZE_EXCEEDED.getStatus())
+                .body(ErrorResponse.of(ErrorCode.FILE_SIZE_EXCEEDED));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 💻 Related Issue
closed #20 
<br/>

## 🚀 Work Description
- [x] MaxUploadSizeExceededException Handler & 커스텀 예외 코드 추가
- GlobalExceptionHandler 에 추가
- FILE_SIZE_EXCEEDED ErrorCode 추가
- [x] 업로드 최대 크기 application.yml 설정
- 단일 이미지 파일 최대 크기 5MB 로 설정
- [x] 한 유저가 동일한 이름의 보호자를 추가할 수 없도록 예외 처리 추가

<br/>

## 🙇🏻‍♀️ To Reviewer
- 프로필과 사기분석시 업로드 하는 이미지 파일 최대 크기 단일 파일 당 5MB 로 넉넉하게 설정 생각했었는데 어떠신가요?
- 유저 정보 수정 api SwaggerResponseDescription 에 이미지 업로드 관련 에러 추가했습니다
- 아직 프로필밖에 이미지 로직이 구현이 안 되어 있어 여러장의 이미지 업로드에대한 사이즈 검증 로직은 테스트해보지 못했습니다

<br/>

## ➕ Next
- pr 확인하시면 application.yml 깃허브 시크릿에 업데이트 하겠습니다!
- 추가 되는 부분
``` 
spring: 
    servlet:
        # MultiPart 업로드 허용 크기
        multipart:
          max-file-size: 5MB        # 단일 파일
          max-request-size: 100MB    # 전체 요청
``` 

 <br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 보호자 이름 중복 등록 방지 기능이 추가되어, 동일한 이름의 보호자를 중복으로 생성하거나 수정할 수 없습니다.
  * 프로필 파일 업로드 시 5MB를 초과하는 경우 오류가 발생하도록 처리되었습니다.

* **버그 수정**
  * 파일 업로드 용량 초과 시 사용자에게 명확한 오류 메시지가 제공됩니다.

* **문서화**
  * Swagger 문서에 새로운 오류 코드 및 상세 오류 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->