### PR TITLE
[Feat] 이메일 중복 확인 API

### DIFF
--- a/src/main/java/com/blockguard/server/domain/auth/api/AuthApi.java
+++ b/src/main/java/com/blockguard/server/domain/auth/api/AuthApi.java
@@ -1,10 +1,8 @@
 package com.blockguard.server.domain.auth.api;
 
 import com.blockguard.server.domain.auth.application.AuthService;
-import com.blockguard.server.domain.user.dto.request.FindEmailRequest;
-import com.blockguard.server.domain.user.dto.request.FindPasswordRequest;
-import com.blockguard.server.domain.user.dto.request.LoginRequest;
-import com.blockguard.server.domain.user.dto.request.RegisterRequest;
+import com.blockguard.server.domain.user.dto.request.*;
+import com.blockguard.server.domain.user.dto.response.CheckEmailDuplicatedResponse;
 import com.blockguard.server.domain.user.dto.response.FindEmailResponse;
 import com.blockguard.server.domain.user.dto.response.LoginResponse;
 import com.blockguard.server.domain.user.dto.response.RegisterResponse;
@@ -36,6 +34,15 @@ public class AuthApi {
 
     }
 
+    @Operation(summary = "이메일 중복 확인", description = "true 반환 시, 이메일 중복")
+    @CustomExceptionDescription(SwaggerResponseDescription.CHECK_EMAIL_DUPLICATED_FAIL)
+    @PostMapping("/register/check-email")
+    public ResponseEntity<BaseResponse<CheckEmailDuplicatedResponse>> checkEmailDuplicated(@Valid @RequestBody CheckEmailDuplicatedRequest CheckEmailDuplicatedRequest) {
+        CheckEmailDuplicatedResponse checkEmailResponse = authService.checkEmailDuplicated(CheckEmailDuplicatedRequest);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.CHECK_EMAIL_DUPLICATED, checkEmailResponse));
+
+    }
+
 
     @Operation(summary = "로그인")
     @CustomExceptionDescription(SwaggerResponseDescription.LOGIN_FAIL)
@@ -48,7 +55,7 @@ public class AuthApi {
     @Operation(summary = "아이디 찾기")
     @CustomExceptionDescription(SwaggerResponseDescription.FIND_EMAIL_FAIL)
     @PostMapping("find-email")
-    public ResponseEntity<BaseResponse<FindEmailResponse>> findEmail(@RequestBody @Valid FindEmailRequest findEmailRequest){
+    public ResponseEntity<BaseResponse<FindEmailResponse>> findEmail(@RequestBody @Valid FindEmailRequest findEmailRequest) {
         FindEmailResponse findEmailResponse = authService.findEmail(findEmailRequest);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.USER_EMAIL_FOUND, findEmailResponse));
     }
@@ -56,7 +63,7 @@ public class AuthApi {
     @Operation(summary = "비밀번호 찾기", description = "이메일이 유효하면 해당 이메일로 임시 비밀번호를 발송합니다.")
     @CustomExceptionDescription(SwaggerResponseDescription.FIND_PASSWORD_FAIL)
     @PostMapping("find-password")
-    public ResponseEntity<BaseResponse<Void>> findPassword(@RequestBody @Valid FindPasswordRequest findPasswordRequest){
+    public ResponseEntity<BaseResponse<Void>> findPassword(@RequestBody @Valid FindPasswordRequest findPasswordRequest) {
         authService.sendTempPassword(findPasswordRequest);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.SEND_TEMP_PASSWORD_BY_EMAIL));
     }

--- a/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
+++ b/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
@@ -3,11 +3,9 @@ package com.blockguard.server.domain.auth.application;
 import com.blockguard.server.domain.auth.domain.JwtToken;
 import com.blockguard.server.domain.auth.infra.JwtTokenGenerator;
 import com.blockguard.server.domain.user.domain.User;
-import com.blockguard.server.domain.user.dto.request.FindEmailRequest;
-import com.blockguard.server.domain.user.dto.request.FindPasswordRequest;
-import com.blockguard.server.domain.user.dto.request.LoginRequest;
+import com.blockguard.server.domain.user.dto.request.*;
 import com.blockguard.server.domain.user.dao.UserRepository;
-import com.blockguard.server.domain.user.dto.request.RegisterRequest;
+import com.blockguard.server.domain.user.dto.response.CheckEmailDuplicatedResponse;
 import com.blockguard.server.domain.user.dto.response.FindEmailResponse;
 import com.blockguard.server.domain.user.dto.response.LoginResponse;
 import com.blockguard.server.domain.user.dto.response.RegisterResponse;
@@ -50,6 +48,14 @@ public class AuthService {
 
         return RegisterResponse.builder()
                 .userId(user.getId())
+                .build();
+    }
+
+
+    public CheckEmailDuplicatedResponse checkEmailDuplicated(CheckEmailDuplicatedRequest CheckEmailDuplicatedRequest) {
+        boolean isDuplicated = userRepository.findByEmail(CheckEmailDuplicatedRequest.getEmail()).isPresent();
+        return CheckEmailDuplicatedResponse.builder()
+                .isDuplicated(isDuplicated)
                 .build();
     }
 
@@ -135,4 +141,5 @@ public class AuthService {
 
         return finalPassword.toString();
     }
+
 }

--- a/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
+++ b/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
@@ -52,8 +52,8 @@ public class AuthService {
     }
 
 
-    public CheckEmailDuplicatedResponse checkEmailDuplicated(CheckEmailDuplicatedRequest CheckEmailDuplicatedRequest) {
-        boolean isDuplicated = userRepository.findByEmail(CheckEmailDuplicatedRequest.getEmail()).isPresent();
+    public CheckEmailDuplicatedResponse checkEmailDuplicated(CheckEmailDuplicatedRequest checkEmailDuplicatedRequest) {
+        boolean isDuplicated = userRepository.findByEmail(checkEmailDuplicatedRequest.getEmail()).isPresent();
         return CheckEmailDuplicatedResponse.builder()
                 .isDuplicated(isDuplicated)
                 .build();

--- a/src/main/java/com/blockguard/server/domain/user/dto/request/CheckEmailDuplicatedRequest.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/request/CheckEmailDuplicatedRequest.java
@@ -1,0 +1,14 @@
+package com.blockguard.server.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckEmailDuplicatedRequest {
+    @Email
+    @NotBlank
+    private String email;
+}

--- a/src/main/java/com/blockguard/server/domain/user/dto/response/CheckEmailDuplicatedResponse.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/response/CheckEmailDuplicatedResponse.java
@@ -1,0 +1,14 @@
+package com.blockguard.server.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CheckEmailDuplicatedResponse {
+    private boolean isDuplicated;
+}

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     /// 4000 ~ : client error
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, 4000, "잘못된 요청 형식입니다. 입력값을 확인해주세요."),
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, 4001, "이미 가입된 이메일입니다."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, 4002, "존재하지 않는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 4003, "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     INVALID_DIRECTORY_ROUTE(HttpStatus.NOT_FOUND, 4022, "잘못된 디렉토리 경로입니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, 4023, "프로필 파일 최대 허용 용량(5MB)을 초과했습니다."),
     DUPLICATE_GUARDIAN_NAME(HttpStatus.BAD_REQUEST, 4024, "이미 등록된 보호자 이름입니다."),
+    INVALID_EMAIL_TYPE(HttpStatus.BAD_REQUEST, 4025, "이메일 형식이 올바르지 않습니다."),
 
     // 5000~ : server error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -21,7 +21,8 @@ public enum SuccessCode {
     GUARDIAN_LIST_RETRIEVED(HttpStatus.OK, 2010, "보호자 목록 조회가 완료되었습니다."),
     GUARDIAN_UPDATED(HttpStatus.OK, 2011, "보호자 정보 수정이 완료되었습니다."),
     GUARDIAN_PRIMARY_UPDATED(HttpStatus.OK, 2012, "보호자 정보 수정이 완료되었습니다."),
-    GUARDIAN_DELETED(HttpStatus.NO_CONTENT, 2013, "보호자 삭제 처리되었습니다.");
+    GUARDIAN_DELETED(HttpStatus.NO_CONTENT, 2013, "보호자 삭제 처리되었습니다."),
+    CHECK_EMAIL_DUPLICATED(HttpStatus.OK, 2014, "이메일 중복 확인이 완료되었습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
@@ -58,6 +58,10 @@ public enum SwaggerResponseDescription {
 
     UPDATE_GUARDIAN_PRIMARY_FAIL(new LinkedHashSet<>(Set.of(
             ErrorCode.GUARDIAN_NOT_FOUND
+    ))),
+
+    CHECK_EMAIL_DUPLICATED_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.INVALID_EMAIL_TYPE
     )));
 
     private final Set<ErrorCode> errorCodeList;


### PR DESCRIPTION
## 💻 Related Issue
closed #23 

<br/>

## 🚀 Work Description
- [x] 이메일 중복 여부 확인 api 작성 완료
<img width="1050" height="708" alt="스크린샷 2025-07-24 16 53 00" src="https://github.com/user-attachments/assets/efadec2d-211c-43fb-9e98-40244d164697" />
- 이메일이 존재하면 true
<img width="997" height="702" alt="스크린샷 2025-07-24 16 53 10" src="https://github.com/user-attachments/assets/bbfddb7f-4828-46fe-b7e7-78edc9c057ae" />
- 존재하지 않다면 false 반환

<br/>

## 🙇🏻‍♀️ To Reviewer
- `GlobalExceptionHandler` 에 유효성 검사 확인관련 코드 추가하였습니다. 유효성 로직에 어긋나는 경우 5000 에러가 아닌 4000 에러가 뜨도록 하였습니다.

<br/>

## ➕ Next
- ocr 연동
 <br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이메일 중복 여부를 확인하는 API 엔드포인트가 추가되었습니다.
  * 이메일 중복 확인 요청 및 응답을 위한 새로운 데이터 전송 객체(DTO)가 도입되었습니다.

* **버그 수정**
  * 이메일 형식이 올바르지 않을 경우와 잘못된 요청에 대해 더 구체적인 에러 메시지가 제공됩니다.

* **문서화**
  * 이메일 중복 확인 실패에 대한 Swagger 응답 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->