### PR TITLE
[Docs] Swagger Error 예시 응답 수정 & 

### DIFF
--- a/src/main/java/com/blockguard/server/domain/guardian/dto/request/CreateGuardianRequest.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/dto/request/CreateGuardianRequest.java
@@ -16,7 +16,7 @@ public class CreateGuardianRequest {
     private String name;
 
     @NotBlank
-    @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "010-1234-5678 형식이어야 합니다.")
+    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "phoneNumber must match 010-1234-5678 format")
     private String phoneNumber;
 
     @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
+++ b/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
@@ -12,6 +12,7 @@ import com.blockguard.server.global.config.swagger.CustomExceptionDescription;
 import com.blockguard.server.global.config.swagger.SwaggerResponseDescription;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -34,7 +35,7 @@ public class UserApi {
     @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_MY_PAGE_INFO_FAIL)
     @Operation(summary = "회원 정보 수정", description = "아이디를 제외하고 수정가능합니다. 생년월일 형식은 'yyyyMMDD'로 입력해야합니다.")
     public BaseResponse<Void> updateUserInfo(@Parameter(hidden = true) @CurrentUser User user,
-                                             @ModelAttribute UpdateUserInfo updateUserInfo){
+                                             @Valid @ModelAttribute UpdateUserInfo updateUserInfo){
         userService.updateUserInfo(user.getId(), updateUserInfo);
         return BaseResponse.of(SuccessCode.UPDATE_USER_INFO_SUCCESS);
 

--- a/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
+++ b/src/main/java/com/blockguard/server/domain/user/api/UserApi.java
@@ -23,6 +23,7 @@ public class UserApi {
     private final UserService userService;
 
     @GetMapping("/me")
+    @CustomExceptionDescription(SwaggerResponseDescription.INVALID_TOKEN)
     @Operation(summary = "마이페이지 조회")
     public BaseResponse<MyPageResponse> getMyPageInfo(@Parameter(hidden = true) @CurrentUser User user){
         MyPageResponse myPageResponse = userService.getMyPageInfo(user);
@@ -40,7 +41,7 @@ public class UserApi {
     }
 
     @PutMapping(value = "/me/password")
-    @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_MY_PAGE_INFO_FAIL)
+    @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_PASSWORD_FAIL)
     @Operation(summary = "비밀번호 변경", description = "현재 비밀번호를 확인하고, 새 비밀번호로 변경합니다.")
     public BaseResponse<Void> updatePassword(@Parameter(hidden = true) @CurrentUser User user,
     @RequestBody UpdatePasswordRequest updatePasswordRequest){
@@ -50,12 +51,11 @@ public class UserApi {
     }
 
     @DeleteMapping("/withdraw")
+    @CustomExceptionDescription(SwaggerResponseDescription.INVALID_TOKEN)
     @Operation(summary = "회원 탈퇴")
     public BaseResponse<Void> withdraw(@Parameter(hidden = true) @CurrentUser User user){
         userService.withdraw(user.getId());
         return BaseResponse.of(SuccessCode.WITHDRAW_SUCCESS);
     }
-
-
 
 }

--- a/src/main/java/com/blockguard/server/domain/user/dto/request/UpdateUserInfo.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/request/UpdateUserInfo.java
@@ -1,5 +1,9 @@
 package com.blockguard.server.domain.user.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,9 +13,19 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 @Builder
 public class UpdateUserInfo {
+    @NotBlank
     private String name;
+
+    @NotBlank
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd")
+    @Schema(description = "생년월일 yyyyMMdd", example = "20000101")
     private String birthDate; //yyyyMMDD
+
+    @NotBlank
+    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$",
+            message = "phoneNumber must match 010-1234-5678 format")
     private String phoneNumber;
+
     private MultipartFile profileImage;
 
 }

--- a/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
@@ -9,7 +9,10 @@ import java.util.Set;
 @Getter
 public enum SwaggerResponseDescription {
     REGISTER_FAIL(new LinkedHashSet<>(Set.of(
-            ErrorCode.DUPLICATED_EMAIL
+            ErrorCode.DUPLICATED_EMAIL,
+            ErrorCode.INVALID_EMAIL_TYPE,
+            ErrorCode.INVALID_PHONE_NUMBER_FORMAT,
+            ErrorCode.INVALID_DATE_FORMAT
     ))),
 
     LOGIN_FAIL(new LinkedHashSet<>(Set.of(
@@ -18,11 +21,14 @@ public enum SwaggerResponseDescription {
     ))),
 
     FIND_EMAIL_FAIL(new LinkedHashSet<>(Set.of(
-            ErrorCode.USER_INFO_NOT_FOUND
+            ErrorCode.USER_INFO_NOT_FOUND,
+            ErrorCode.INVALID_PHONE_NUMBER_FORMAT,
+            ErrorCode.INVALID_DATE_FORMAT
     ))),
 
     UPDATE_MY_PAGE_INFO_FAIL(new LinkedHashSet<>(Set.of(
             ErrorCode.INVALID_PHONE_NUMBER_FORMAT,
+            ErrorCode.INVALID_DATE_FORMAT,
             ErrorCode.INVALID_PROFILE_IMAGE,
             ErrorCode.INVALID_TOKEN,
             ErrorCode.FILE_NAME_NOT_FOUND,
@@ -36,7 +42,8 @@ public enum SwaggerResponseDescription {
     ))),
 
     FIND_PASSWORD_FAIL(new LinkedHashSet<>(Set.of(
-            ErrorCode.EMAIL_NOT_FOUND
+            ErrorCode.EMAIL_NOT_FOUND,
+            ErrorCode.INVALID_EMAIL_TYPE
     ))),
 
     FIND_GUARDIANS_FAIL(new LinkedHashSet<>(Set.of(

--- a/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
@@ -24,6 +24,7 @@ public enum SwaggerResponseDescription {
     UPDATE_MY_PAGE_INFO_FAIL(new LinkedHashSet<>(Set.of(
             ErrorCode.INVALID_PHONE_NUMBER_FORMAT,
             ErrorCode.INVALID_PROFILE_IMAGE,
+            ErrorCode.INVALID_TOKEN,
             ErrorCode.FILE_NAME_NOT_FOUND,
             ErrorCode.INVALID_DIRECTORY_ROUTE,
             ErrorCode.FILE_SIZE_EXCEEDED
@@ -34,10 +35,12 @@ public enum SwaggerResponseDescription {
     ))),
 
     FIND_GUARDIANS_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.INVALID_TOKEN,
             ErrorCode.USER_INFO_NOT_FOUND
     ))),
 
     CREATE_GUARDIAN_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.INVALID_TOKEN,
             ErrorCode.INVALID_PHONE_NUMBER_FORMAT,
             ErrorCode.INVALID_PROFILE_IMAGE,
             ErrorCode.FILE_NAME_NOT_FOUND,
@@ -47,6 +50,7 @@ public enum SwaggerResponseDescription {
     ))),
 
     UPDATE_GUARDIAN_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.INVALID_TOKEN,
             ErrorCode.INVALID_PHONE_NUMBER_FORMAT,
             ErrorCode.INVALID_PROFILE_IMAGE,
             ErrorCode.GUARDIAN_NOT_FOUND,
@@ -57,6 +61,7 @@ public enum SwaggerResponseDescription {
     ))),
 
     UPDATE_GUARDIAN_PRIMARY_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.INVALID_TOKEN,
             ErrorCode.GUARDIAN_NOT_FOUND
     ))),
 
@@ -68,10 +73,9 @@ public enum SwaggerResponseDescription {
 
     SwaggerResponseDescription(Set<ErrorCode> errorCodes) {
         // 공통 에러 추가
-        errorCodes.addAll(Set.of(
-                ErrorCode.INVALID_TOKEN,
+        errorCodes.add(
                 ErrorCode.INTERNAL_SERVER_ERROR
-        ));
+        );
 
         this.errorCodeList = errorCodes;
     }

--- a/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
@@ -30,6 +30,11 @@ public enum SwaggerResponseDescription {
             ErrorCode.FILE_SIZE_EXCEEDED
     ))),
 
+    UPDATE_PASSWORD_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.INVALID_TOKEN,
+            ErrorCode.PASSWORD_MISMATCH
+    ))),
+
     FIND_PASSWORD_FAIL(new LinkedHashSet<>(Set.of(
             ErrorCode.EMAIL_NOT_FOUND
     ))),
@@ -67,6 +72,10 @@ public enum SwaggerResponseDescription {
 
     CHECK_EMAIL_DUPLICATED_FAIL(new LinkedHashSet<>(Set.of(
             ErrorCode.INVALID_EMAIL_TYPE
+    ))),
+
+    INVALID_TOKEN(new LinkedHashSet<>(Set.of(
+            ErrorCode.INVALID_TOKEN
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/com/blockguard/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/blockguard/server/global/exception/GlobalExceptionHandler.java
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler {
 
         log.warn("[ValidationException] message: {}", message);
 
-        if (message.contains("이메일 형식")) {
+        if (message.contains("이메일")) {
             return ResponseEntity
                     .status(ErrorCode.INVALID_EMAIL_TYPE.getStatus())
                     .body(ErrorResponse.of(ErrorCode.INVALID_EMAIL_TYPE));


### PR DESCRIPTION
## 💻 Related Issue
closed #25 
<br/>

## 🚀 Work Description
- [x] Swagger Error Description 수정
- [x] 공통 에러에서 INVALID_TOKEN 제외
- 토큰을 헤더로 보내지 않는 api 도 있기 때문에 공통 에러에서 INVALID_TOKEN를 제거하였고, 실제 api 응답으로 나올 수 있는 예외들로 Swagger 문서를 수정했습니다.

<br/>

## 🙇🏻‍♀️ To Reviewer
- 생년월일과 전화번호 예외 처리 핸들러를 GlobalExceptionHandler 에 추가하였습니다.
- user update api 의 request dto 에 형식 검증 작업을 추가하였습니다.

<br/>

