### PR TITLE
[Feat] 사기 분석 API 및 OCR API 연동

### DIFF
--- a/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
@@ -3,8 +3,10 @@ package com.blockguard.server.domain.analysis.api;
 import com.blockguard.server.domain.analysis.application.FraudAnalysisService;
 import com.blockguard.server.domain.analysis.dto.request.FraudAnalysisRequest;
 import com.blockguard.server.domain.analysis.dto.response.FraudAnalysisResponse;
+import com.blockguard.server.global.common.codes.ErrorCode;
 import com.blockguard.server.global.common.codes.SuccessCode;
 import com.blockguard.server.global.common.response.BaseResponse;
+import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +32,11 @@ public class FraudAnalysisApi {
             (@RequestParam("fraudAnalysisRequest") String jsonStr,
              @RequestParam(value = "imageFiles", required = false) List<MultipartFile> imageFiles
             ) throws JsonProcessingException {
+
+        if (imageFiles != null && imageFiles.size() > 2) {
+            throw new BusinessExceptionHandler(ErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED);
+        }
+
         FraudAnalysisRequest request = objectMapper.readValue(jsonStr, FraudAnalysisRequest.class);
         FraudAnalysisResponse fraudAnalysisResponse = fraudAnalysisService.fraudAnalysis(request, imageFiles);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.ANALYZE_FRAUD_SUCCESS, fraudAnalysisResponse));

--- a/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
@@ -1,0 +1,26 @@
+package com.blockguard.server.domain.analysis.api;
+
+import com.blockguard.server.domain.analysis.application.FraudAnalysisService;
+import com.blockguard.server.domain.analysis.dto.request.FraudAnalysisRequest;
+import com.blockguard.server.domain.analysis.dto.response.FraudAnalysisResponse;
+import com.blockguard.server.global.common.codes.SuccessCode;
+import com.blockguard.server.global.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api")
+public class FraudAnalysisApi {
+
+    private final FraudAnalysisService fraudAnalysisService;
+
+    @PostMapping("/fraud-analysis")
+    @Operation(summary = "사기 분석")
+    public ResponseEntity<BaseResponse<FraudAnalysisResponse>> analyzeFraud(@ModelAttribute FraudAnalysisRequest fraudAnalysisRequest) {
+        FraudAnalysisResponse fraudAnalysisResponse = fraudAnalysisService.fraudAnalysis(fraudAnalysisRequest);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.ANALYZE_FRAUD_SUCCESS, fraudAnalysisResponse));
+    }
+}

--- a/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
@@ -5,10 +5,16 @@ import com.blockguard.server.domain.analysis.dto.request.FraudAnalysisRequest;
 import com.blockguard.server.domain.analysis.dto.response.FraudAnalysisResponse;
 import com.blockguard.server.global.common.codes.SuccessCode;
 import com.blockguard.server.global.common.response.BaseResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @AllArgsConstructor
@@ -16,11 +22,16 @@ import org.springframework.web.bind.annotation.*;
 public class FraudAnalysisApi {
 
     private final FraudAnalysisService fraudAnalysisService;
+    private final ObjectMapper objectMapper;
 
-    @PostMapping("/fraud-analysis")
+    @PostMapping(value = "/fraud-analysis", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "사기 분석")
-    public ResponseEntity<BaseResponse<FraudAnalysisResponse>> analyzeFraud(@ModelAttribute FraudAnalysisRequest fraudAnalysisRequest) {
-        FraudAnalysisResponse fraudAnalysisResponse = fraudAnalysisService.fraudAnalysis(fraudAnalysisRequest);
+    public ResponseEntity<BaseResponse<FraudAnalysisResponse>> analyzeFraud
+            (@RequestParam("fraudAnalysisRequest") String jsonStr,
+             @RequestParam(value = "imageFiles", required = false) List<MultipartFile> imageFiles
+            ) throws JsonProcessingException {
+        FraudAnalysisRequest request = objectMapper.readValue(jsonStr, FraudAnalysisRequest.class);
+        FraudAnalysisResponse fraudAnalysisResponse = fraudAnalysisService.fraudAnalysis(request, imageFiles);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.ANALYZE_FRAUD_SUCCESS, fraudAnalysisResponse));
     }
 }

--- a/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
@@ -5,29 +5,33 @@ import com.blockguard.server.domain.analysis.dto.request.GptRequest;
 import com.blockguard.server.domain.analysis.dto.response.FraudAnalysisResponse;
 import com.blockguard.server.infra.ocr.NaverOcrClient;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@Slf4j
 @AllArgsConstructor
 public class FraudAnalysisService {
 
     private final NaverOcrClient naverOcrClient;
 
-    public FraudAnalysisResponse fraudAnalysis(FraudAnalysisRequest fraudAnalysisRequest) {
+    public FraudAnalysisResponse fraudAnalysis(FraudAnalysisRequest fraudAnalysisRequest, List<MultipartFile> imageFiles) {
         List<String> keywords = new ArrayList<>();
 
         extractKeywordsFromRequest(fraudAnalysisRequest, keywords);
         String additionalDescription = fraudAnalysisRequest.getAdditionalDescription();
         String imageContent = "";
-        imageContent = extractOcrText(fraudAnalysisRequest, imageContent);
+        imageContent = extractOcrText(imageFiles);
 
         GptRequest gptRequest = buildGptRequest(fraudAnalysisRequest, keywords, additionalDescription, imageContent);
 
-        FraudAnalysisResponse fraudAnalysisResponse = FraudAnalysisResponse
+        return FraudAnalysisResponse
                 .builder()
                 .keywords(keywords)
                 .additionalDescription(additionalDescription)
@@ -35,21 +39,26 @@ public class FraudAnalysisService {
                 .imageContent(StringUtils.hasText(imageContent) ? imageContent : null)
                 .build();
 
-        return fraudAnalysisResponse;
-
     }
 
-    private String extractOcrText(FraudAnalysisRequest fraudAnalysisRequest, String imageContent) {
-        List<String> imageUrls = fraudAnalysisRequest.getImageUrls();
-        if (imageUrls != null && !imageUrls.isEmpty()){
-            List<String> imageContents = new ArrayList<>();
-            imageUrls.forEach(url -> {
-                String result = naverOcrClient.extractTextFromImage(List.of(url));
-                if (!result.isBlank()) imageContents.add(result);
-            });
-            imageContent = String.join(" ", imageContents);
+    private String extractOcrText(List<MultipartFile> imageFiles) {
+        if (imageFiles == null || imageFiles.isEmpty()) return "";
+
+        List<String> imageContents = new ArrayList<>();
+        for (MultipartFile file : imageFiles) {
+            try {
+                byte[] imageBytes = file.getBytes();
+                String fileName = file.getOriginalFilename();
+                String result = naverOcrClient.extractTextFromImage(imageBytes, fileName);
+                if (StringUtils.hasText(result)) {
+                    imageContents.add(result);
+                }
+            } catch (IOException e) {
+                log.error("이미지 OCR 실패: {}", e.getMessage());
+            }
         }
-        return imageContent;
+
+        return String.join(" ", imageContents);
     }
 
     private static void extractKeywordsFromRequest(FraudAnalysisRequest fraudAnalysisRequest, List<String> keywords) {

--- a/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
@@ -29,6 +29,7 @@ public class FraudAnalysisService {
         String imageContent = "";
         imageContent = extractOcrText(imageFiles);
 
+        // TODO: gpt 서버와 연동 예정
         GptRequest gptRequest = buildGptRequest(fraudAnalysisRequest, keywords, additionalDescription, imageContent);
 
         return FraudAnalysisResponse

--- a/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
@@ -1,0 +1,75 @@
+package com.blockguard.server.domain.analysis.application;
+
+import com.blockguard.server.domain.analysis.dto.request.FraudAnalysisRequest;
+import com.blockguard.server.domain.analysis.dto.request.GptRequest;
+import com.blockguard.server.domain.analysis.dto.response.FraudAnalysisResponse;
+import com.blockguard.server.infra.ocr.NaverOcrClient;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class FraudAnalysisService {
+
+    private final NaverOcrClient naverOcrClient;
+
+    public FraudAnalysisResponse fraudAnalysis(FraudAnalysisRequest fraudAnalysisRequest) {
+        List<String> keywords = new ArrayList<>();
+
+        String additionalDescription = extractKeywordsFromRequest(fraudAnalysisRequest, keywords);
+        String imageContent = extractOcrText(fraudAnalysisRequest);
+        sendToGpt(fraudAnalysisRequest, keywords, additionalDescription, imageContent);
+
+        FraudAnalysisResponse fraudAnalysisResponse = FraudAnalysisResponse
+                .builder()
+                .keywords(keywords)
+                .additionalDescription(additionalDescription)
+                .messageContent(StringUtils.hasText(fraudAnalysisRequest.getMessageContent()) ? fraudAnalysisRequest.getMessageContent() : null)
+                .imageContent(StringUtils.hasText(imageContent) ? imageContent : null)
+                .build();
+
+        return fraudAnalysisResponse;
+
+    }
+
+    private String extractOcrText(FraudAnalysisRequest fraudAnalysisRequest) {
+        String imageContent = "";
+        List<String> imageUrls = fraudAnalysisRequest.getImageUrls();
+        if (imageUrls != null && !imageUrls.isEmpty()){
+            List<String> imageContents = new ArrayList<>();
+            imageUrls.forEach(url -> {
+                String result = naverOcrClient.extractTextFromImage(List.of(url));
+                if (!result.isBlank()) imageContents.add(result);
+            });
+            imageContent = String.join(" ", imageContents);
+        }
+        return imageContent;
+    }
+
+    private static String extractKeywordsFromRequest(FraudAnalysisRequest fraudAnalysisRequest, List<String> keywords) {
+        if (StringUtils.hasText(fraudAnalysisRequest.getContactMethod()))
+            keywords.add(fraudAnalysisRequest.getContactMethod());
+        if (StringUtils.hasText(fraudAnalysisRequest.getCounterpart()))
+            keywords.add(fraudAnalysisRequest.getCounterpart());
+        if (fraudAnalysisRequest.getRequestedAction() != null && !fraudAnalysisRequest.getRequestedAction().isEmpty())
+            keywords.addAll(fraudAnalysisRequest.getRequestedAction());
+        if (fraudAnalysisRequest.getRequestedInfo() != null && !fraudAnalysisRequest.getRequestedInfo().isEmpty())
+            keywords.addAll(fraudAnalysisRequest.getRequestedInfo());
+        if (StringUtils.hasText(fraudAnalysisRequest.getAppType())) keywords.add(fraudAnalysisRequest.getAppType());
+        String additionalDescription = fraudAnalysisRequest.getAdditionalDescription();
+        return additionalDescription;
+    }
+
+    private static void sendToGpt(FraudAnalysisRequest fraudAnalysisRequest, List<String> keywords, String additionalDescription, String imageContent) {
+        GptRequest gptRequest = GptRequest.builder()
+                .keywords(keywords)
+                .additionalDescription(additionalDescription)
+                .messageContent(StringUtils.hasText(fraudAnalysisRequest.getMessageContent()) ? fraudAnalysisRequest.getMessageContent() : null)
+                .imageContent(StringUtils.hasText(imageContent) ? imageContent : null)
+                .build();
+    }
+}

--- a/src/main/java/com/blockguard/server/domain/analysis/dto/request/FraudAnalysisRequest.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/dto/request/FraudAnalysisRequest.java
@@ -2,10 +2,12 @@ package com.blockguard.server.domain.analysis.dto.request;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class FraudAnalysisRequest {
     private String contactMethod;
@@ -16,8 +18,6 @@ public class FraudAnalysisRequest {
     private Boolean atmGuided; // 선택
     private String suspiciousLinks; // 선택
     private String suspiciousPhoneNumbers; // 선택
-    private List<String> imageUrls; // 선택
     private String messageContent; // 선택
     private String additionalDescription;
-
 }

--- a/src/main/java/com/blockguard/server/domain/analysis/dto/request/FraudAnalysisRequest.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/dto/request/FraudAnalysisRequest.java
@@ -1,0 +1,23 @@
+package com.blockguard.server.domain.analysis.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class FraudAnalysisRequest {
+    private String contactMethod;
+    private String counterpart;
+    private List<String> requestedAction;
+    private List<String> requestedInfo;
+    private String appType; // 선택
+    private Boolean atmGuided; // 선택
+    private String suspiciousLinks; // 선택
+    private String suspiciousPhoneNumbers; // 선택
+    private List<String> imageUrls; // 선택
+    private String messageContent; // 선택
+    private String additionalDescription;
+
+}

--- a/src/main/java/com/blockguard/server/domain/analysis/dto/request/GptRequest.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/dto/request/GptRequest.java
@@ -1,0 +1,15 @@
+package com.blockguard.server.domain.analysis.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class GptRequest {
+    private String messageContent;
+    private List<String> keywords;
+    private String additionalDescription;
+    private String imageContent;
+}

--- a/src/main/java/com/blockguard/server/domain/analysis/dto/response/FraudAnalysisResponse.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/dto/response/FraudAnalysisResponse.java
@@ -1,0 +1,17 @@
+package com.blockguard.server.domain.analysis.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class FraudAnalysisResponse {
+    // for test
+    private String messageContent;
+    private List<String> keywords;
+    private String additionalDescription;
+    private String imageContent;
+}

--- a/src/main/java/com/blockguard/server/domain/analysis/dto/response/FraudAnalysisResponse.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/dto/response/FraudAnalysisResponse.java
@@ -1,5 +1,6 @@
 package com.blockguard.server.domain.analysis.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,8 @@ import java.util.List;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class FraudAnalysisResponse {
     // for test
     private String messageContent;

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, 4023, "프로필 파일 최대 허용 용량(5MB)을 초과했습니다."),
     DUPLICATE_GUARDIAN_NAME(HttpStatus.BAD_REQUEST, 4024, "이미 등록된 보호자 이름입니다."),
     INVALID_EMAIL_TYPE(HttpStatus.BAD_REQUEST, 4025, "이메일 형식이 올바르지 않습니다."),
+    IMAGE_UPLOAD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, 4026, "이미지는 최대 2장까지만 업로드 가능합니다."),
 
     // 5000~ : server error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -22,7 +22,8 @@ public enum SuccessCode {
     GUARDIAN_UPDATED(HttpStatus.OK, 2011, "보호자 정보 수정이 완료되었습니다."),
     GUARDIAN_PRIMARY_UPDATED(HttpStatus.OK, 2012, "보호자 정보 수정이 완료되었습니다."),
     GUARDIAN_DELETED(HttpStatus.NO_CONTENT, 2013, "보호자 삭제 처리되었습니다."),
-    CHECK_EMAIL_DUPLICATED(HttpStatus.OK, 2014, "이메일 중복 확인이 완료되었습니다.");
+    CHECK_EMAIL_DUPLICATED(HttpStatus.OK, 2014, "이메일 중복 확인이 완료되었습니다."),
+    ANALYZE_FRAUD_SUCCESS(HttpStatus.OK, 2015, "사기 분석이 완료되었습니다."),;
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/config/MultipartConfig.java
+++ b/src/main/java/com/blockguard/server/global/config/MultipartConfig.java
@@ -1,0 +1,15 @@
+package com.blockguard.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.multipart.MultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
+
+@Configuration
+public class MultipartConfig {
+
+    @Bean
+    public MultipartResolver multipartResolver() {
+        return new StandardServletMultipartResolver();
+    }
+}

--- a/src/main/java/com/blockguard/server/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/blockguard/server/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.blockguard.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/blockguard/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/blockguard/server/global/config/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests((registry) ->
                         registry
                                 .requestMatchers("/api/auth/**").permitAll()   // 로그인/회원가입만 허용
+                                .requestMatchers("/api/fraud-analysis").permitAll()
+                                .requestMatchers("/api/test").permitAll()
                                 .requestMatchers("/actuator/health").permitAll() // 헬스체크 허용
                                 .requestMatchers("/", "/index.html", "/favicon.ico").permitAll()
                                 .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**", "/webjars/**").permitAll()

--- a/src/main/java/com/blockguard/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/blockguard/server/global/config/SecurityConfig.java
@@ -55,7 +55,6 @@ public class SecurityConfig {
                         registry
                                 .requestMatchers("/api/auth/**").permitAll()   // 로그인/회원가입만 허용
                                 .requestMatchers("/api/fraud-analysis").permitAll()
-                                .requestMatchers("/api/test").permitAll()
                                 .requestMatchers("/actuator/health").permitAll() // 헬스체크 허용
                                 .requestMatchers("/", "/index.html", "/favicon.ico").permitAll()
                                 .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**", "/webjars/**").permitAll()

--- a/src/main/java/com/blockguard/server/infra/ocr/ByteArrayResourceWithFilename.java
+++ b/src/main/java/com/blockguard/server/infra/ocr/ByteArrayResourceWithFilename.java
@@ -1,0 +1,18 @@
+package com.blockguard.server.infra.ocr;
+
+import org.springframework.core.io.ByteArrayResource;
+
+public class ByteArrayResourceWithFilename extends ByteArrayResource {
+    private final String filename;
+
+    public ByteArrayResourceWithFilename(byte[] byteArray, String filename) {
+        super(byteArray);
+        this.filename = filename;
+    }
+
+    @Override
+    public String getFilename() {
+        return filename;
+    }
+
+}

--- a/src/main/java/com/blockguard/server/infra/ocr/NaverOcrClient.java
+++ b/src/main/java/com/blockguard/server/infra/ocr/NaverOcrClient.java
@@ -1,0 +1,75 @@
+package com.blockguard.server.infra.ocr;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverOcrClient {
+
+    @Value("${naver.ocr.invoke-url}")
+    private String invokeUrl;
+
+    @Value("${naver.ocr.secret-key}")
+    private String secretKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public String extractTextFromImage(List<String> imageUrls) {
+        List<Map<String, Object>> images = imageUrls.stream()
+                .map(url -> {
+                    Map<String, Object> image = Map.of(
+                        "format", "jpg",
+                        "name", "ocrImage",
+                        "url", url
+                    );
+                    return image;
+                })
+                .collect(Collectors.toList());
+
+        Map<String, Object> payload = Map.of(
+                "version", "V2",
+                "requestId", UUID.randomUUID().toString(),
+                "timestamp", System.currentTimeMillis(),
+                "lang", "ko",
+                "images", images,
+                "enableTableDetection", false
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("X-OCR-SECRET", secretKey);
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    invokeUrl,
+                    HttpMethod.POST,
+                    request,
+                    Map.class
+            );
+
+            List<Map<String, Object>> imageResponses = (List<Map<String, Object>>) response.getBody().get("images");
+
+            return imageResponses.stream()
+                    .flatMap(image -> ((List<Map<String, Object>>) image.get("fields")).stream())
+                    .map(field -> (String) field.get("inferText"))
+                    .collect(Collectors.joining(" "));
+
+        } catch (Exception e) {
+            log.error("❌ OCR 실패: {}", e.getMessage());
+            return "";
+        }
+    }
+}

--- a/src/main/java/com/blockguard/server/infra/ocr/NaverOcrClient.java
+++ b/src/main/java/com/blockguard/server/infra/ocr/NaverOcrClient.java
@@ -27,7 +27,7 @@ public class NaverOcrClient {
     @Value("${naver.ocr.secret-key}")
     private String secretKey;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
     public String extractTextFromImage(byte[] imageBytes, String fileName) {
         log.info("ocr api 호출");

--- a/src/main/java/com/blockguard/server/infra/ocr/NaverOcrClient.java
+++ b/src/main/java/com/blockguard/server/infra/ocr/NaverOcrClient.java
@@ -76,8 +76,6 @@ public class NaverOcrClient {
                     Map.class
             );
 
-            log.info("OCR 응답: {}", new ObjectMapper().writeValueAsString(response.getBody()));
-
             List<Map<String, Object>> imageResponses = (List<Map<String, Object>>) response.getBody().get("images");
 
             return imageResponses.stream()


### PR DESCRIPTION
## 💻 Related Issue
close #21 

<br/>

## 🚀 Work Description
- 사기 분석 api 연동

- api 명세서 수정 
: 기존에 각각의 필드를 따로 응답 받는 방식에서 multipart 파싱 오류가 계속 생겨, fraudAnalysisRequest 로 json 형태 한 번에 응답 + 이미지 선택 첨부

- 네이버 ocr api 연동 완료
: api 호출 한 건당 돈 나감.. 이미지 별도로 첨부 안 할 경우 호출 안 되게 막아놨고 최대 몇 장까지 첨부가능하게 할지 다시 pm님과 논의 필요 

- gpt 서버 전달 용으로 응답 생성 완료
<img width="2236" height="1150" alt="image" src="https://github.com/user-attachments/assets/cdef729f-f29f-4872-bed9-c407fc5b56d8" />
: 논의했던 대로 사용자가 선택한 설문 조사 결과는 keywords에 list 형태로, imageContent는 ocr api 응답값, additionalDescription 및 messageContent는 사용자가 입력한 값 전송 & 현재 gpt 서버와 연동 전이라 해당 api 호출 시 사진과 같은 결과 값 반환됨

<br/>

## 🙇🏻‍♀️ To Reviewer
- 사진 첨부 가능 개수 다시 이야기해봐야할 것 같습니다..
- ocr api 성능은 좋은거같은데 gpt 학습에 도움이 될지 안될지는 모르겠네요 
- 그리고 gpt 서버에 데이터 전달하기위해 연동해야할 것 같은데 혹시 준비 되어있을까요??

<br/>

## ➕ Next
 <br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사기 분석을 위한 새로운 REST API 엔드포인트(/api/fraud-analysis) 추가: JSON 데이터와 최대 2장의 이미지 파일 업로드로 사기 분석 요청 가능.
  * 이미지 내 문자 인식(OCR) 기능 지원: 업로드된 이미지에서 텍스트를 추출하여 분석에 활용.
  * 분석 결과로 키워드, 추가 설명, 메시지 내용, 이미지 추출 텍스트 등이 포함된 응답 제공.

* **설정**
  * 파일 업로드 처리를 위한 멀티파트 설정 추가.
  * 사기 분석 API에 대한 인증 없이 접근 가능하도록 보안 설정 변경.
  * HTTP 요청 처리를 위한 RestTemplate 빈 추가.

* **기타**
  * 이미지 업로드 제한(최대 2장) 관련 오류 코드 추가.
  * 사기 분석 성공 시 반환되는 새로운 성공 코드 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->