### PR TITLE
[Refactor] 공공데이터 API 버전 변경

### DIFF
--- a/src/main/java/com/blockguard/server/infra/importer/FraudUrlImporter.java
+++ b/src/main/java/com/blockguard/server/infra/importer/FraudUrlImporter.java
@@ -48,11 +48,11 @@ public class FraudUrlImporter {
     @Transactional
     public void syncFraudUrlsFromOpenApi() {
 
-  /*      log.info("2024 버전 사기 URL 동기화 시작");
-        importFrom(apiUrl);*/
+        log.info("2024 버전 사기 URL 동기화 시작");
+        importFrom(apiUrl);
 
-        log.info("2023 버전 사기 URL 동기화 시작");
-        importFrom(apiUrlOld);
+/*        log.info("2023 버전 사기 URL 동기화 시작");
+        importFrom(apiUrlOld);*/
     }
 
     private void importFrom(String baseUrl) {


### PR DESCRIPTION
## 💻 Related Issue

<br/>

## 🚀 Work Description
- [x] 2024 버전으로 변경 완료

<br/>

## 🙇🏻‍♀️ To Reviewer
- Nginx Timeout 오류 발생 -> `syncFraudUrlsFromOpenApi` 비동기 호출 방식으로 변경
- bulk insert 방식으로 DB 삽입 시간 단축
- 현재 서버 DB에 2023, 2024 데이터 담겨있습니다. 로컬 DB에 저장하고 싶으시면 `FraudUrlImporter` 클래스에서 2023 버전으로 `/api/admin/update/fraud-url` 한 번 호출해주시고, 완료되면 2024버전으로 호출한 후에 2024 버전으로 두시면 됩니다.
- 데이터가 두 개 합치면 약 5만개 정도로 양이 꽤나 많아 저장하는데 시간이 걸립니다.
- 오류 해결하느라 url api 관련해서 pr을 많이 올렸네요 ㅠㅠ. 다음부터는 처음부터 잘해보도록 노력 또 노력하겠듭니다...

<br/>

## ➕ Next
- 뉴스 api 작성

 <br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 2024년 버전의 사기 URL 동기화 기능이 활성화되고, 2023년 버전의 동기화가 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->