### PR TITLE
[Refactor] 관리자용 API 추가

### DIFF
--- a/src/main/java/com/blockguard/server/domain/admin/api/AdminApi.java
+++ b/src/main/java/com/blockguard/server/domain/admin/api/AdminApi.java
@@ -1,27 +1,45 @@
 package com.blockguard.server.domain.admin.api;
 
-import com.blockguard.server.domain.news.application.NewsService;
+import com.blockguard.server.domain.auth.domain.JwtToken;
+import com.blockguard.server.domain.auth.enums.JwtGrantType;
+import com.blockguard.server.domain.auth.infra.JwtTokenGenerator;
 import com.blockguard.server.domain.news.scheduler.NewsSaveScheduler;
+import com.blockguard.server.global.common.codes.ErrorCode;
 import com.blockguard.server.global.common.codes.SuccessCode;
 import com.blockguard.server.global.common.response.BaseResponse;
-import com.blockguard.server.infra.crawler.DaumNewsCrawler;
+import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import com.blockguard.server.infra.importer.FraudUrlImporter;
 import io.swagger.v3.oas.annotations.Operation;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@AllArgsConstructor
+@RequiredArgsConstructor
 @RequestMapping("/api/admin")
 @Slf4j
 public class AdminApi {
 
     private final FraudUrlImporter fraudUrlImporter;
-    private NewsSaveScheduler newsSaveScheduler;
+    private final NewsSaveScheduler newsSaveScheduler;
+    private final JwtTokenGenerator jwtTokenGenerator;
+
+    @Value("${jwt.admin-secret}")
+    private String adminSecret;
+
+    @PostMapping("/login")
+    public BaseResponse<JwtToken> loginAdmin(@RequestParam String key) {
+        if (!adminSecret.equals(key)) {
+            throw new BusinessExceptionHandler(ErrorCode.INVALID_TOKEN);
+        }
+
+        JwtToken token = jwtTokenGenerator.generateToken("admin", JwtGrantType.GRANT_TYPE_ADMIN.getValue());
+        return BaseResponse.of(SuccessCode.ADMIN_TOKEN_SUCCESS, token);
+    }
 
     @PostMapping("/update/fraud-url")
     @Operation(summary = "공공 api 데이터 호출 - 관리자용")

--- a/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
+++ b/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
@@ -1,6 +1,7 @@
 package com.blockguard.server.domain.auth.application;
 
 import com.blockguard.server.domain.auth.domain.JwtToken;
+import com.blockguard.server.domain.auth.enums.JwtGrantType;
 import com.blockguard.server.domain.auth.infra.JwtTokenGenerator;
 import com.blockguard.server.domain.user.domain.User;
 import com.blockguard.server.domain.user.dto.request.*;
@@ -67,7 +68,7 @@ public class AuthService {
             throw new BusinessExceptionHandler(ErrorCode.INVALID_PASSWORD);
         }
 
-        JwtToken jwtToken = jwtTokenGenerator.generateToken(user.getId(), "Bearer");
+        JwtToken jwtToken = jwtTokenGenerator.generateToken(user.getId().toString(), JwtGrantType.GRANT_TYPE_USER.getValue());
 
         return LoginResponse.builder()
                 .userId(user.getId())

--- a/src/main/java/com/blockguard/server/domain/auth/infra/JwtTokenGenerator.java
+++ b/src/main/java/com/blockguard/server/domain/auth/infra/JwtTokenGenerator.java
@@ -25,7 +25,7 @@ public class JwtTokenGenerator {
     }
 
     // User 정보를 가지고 AccessToken, RefreshToken을 생성
-    public JwtToken generateToken(Long userId, String grantType) {
+    public JwtToken generateToken(String userId, String grantType) {
         // 권한 가져오기
         long now = (new Date()).getTime();
 
@@ -38,7 +38,8 @@ public class JwtTokenGenerator {
         Date accessTokenExpiresIn = new Date(now + accessTokenExpireTime);
         String accessToken = Jwts.builder()
                 .setSubject(String.valueOf(userId))
-                .claim("auth", "ROLE_USER")
+                //.claim("auth", "ROLE_USER")
+                .claim("auth", "ROLE_" + grantType.toUpperCase())
                 .setExpiration(accessTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();

--- a/src/main/java/com/blockguard/server/domain/auth/interceptor/AdminCheckInterceptor.java
+++ b/src/main/java/com/blockguard/server/domain/auth/interceptor/AdminCheckInterceptor.java
@@ -1,0 +1,34 @@
+package com.blockguard.server.domain.auth.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.security.core.GrantedAuthority;
+
+@Component
+public class AdminCheckInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그인이 필요합니다.");
+            return false;
+        }
+
+        String grantType = (String) authentication.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElse("");
+
+        if (!"ROLE_ADMIN".equals(grantType)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "관리자 권한이 없습니다.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -32,7 +32,8 @@ public enum SuccessCode {
     STEP_INFO_FOUND(HttpStatus.OK,2021, "신고 단계 정보 조회에 성공하였습니다."),
     UPDATE_STEP_INFO_SUCCESS(HttpStatus.OK,2022, "신고 단계 정보가 성공적으로 업데이트 되었습니다."),
     GET_NEWS_ARTICLES_SUCCESS(HttpStatus.OK, 2023, "뉴스 목록 조회가 완료되었습니다."),
-    CRWAL_DAUM_NEWS_SUCCESS(HttpStatus.OK, 2024, "뉴스 크롤링이 완료되었습니다.");
+    CRWAL_DAUM_NEWS_SUCCESS(HttpStatus.OK, 2024, "뉴스 크롤링이 완료되었습니다."),
+    ADMIN_TOKEN_SUCCESS(HttpStatus.OK, 2025, "관리자 토큰이 발급되었습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/blockguard/server/global/config/SecurityConfig.java
@@ -54,8 +54,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests((registry) ->
                         registry
                                 .requestMatchers("/api/auth/**").permitAll()   // 로그인 및 회원가입
-                                .requestMatchers("/api/admin/update/fraud-url", "/api/fraud/url", "/api/fraud-analysis").permitAll() // 사기 분석
-                                .requestMatchers("/api/news", "/api/admin/crawl").permitAll() // 뉴스 조회
+                                .requestMatchers("/api/admin/login").permitAll()   // 관리자 로그인
+                                .requestMatchers("/api/fraud/url", "/api/fraud-analysis").permitAll() // 사기 분석
+                                .requestMatchers("/api/news").permitAll() // 뉴스 조회
                                 .requestMatchers("/actuator/health").permitAll() // 헬스체크 허용
                                 .requestMatchers("/", "/index.html", "/favicon.ico").permitAll()
                                 .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**", "/webjars/**").permitAll()

--- a/src/main/java/com/blockguard/server/global/config/WebMvcConfig.java
+++ b/src/main/java/com/blockguard/server/global/config/WebMvcConfig.java
@@ -1,10 +1,12 @@
 package com.blockguard.server.global.config;
 
+import com.blockguard.server.domain.auth.interceptor.AdminCheckInterceptor;
 import com.blockguard.server.global.config.resolver.CurrentUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -14,6 +16,8 @@ import java.util.List;
 public class WebMvcConfig implements WebMvcConfigurer {
     private final long MAX_AGE_SECS = 3600;
     private final CurrentUserArgumentResolver currentUserArgumentResolver;
+    private final AdminCheckInterceptor adminCheckInterceptor;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -27,6 +31,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(currentUserArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(adminCheckInterceptor)
+                .addPathPatterns("/api/admin/**")
+                .excludePathPatterns("/api/admin/login");
     }
 
 }


### PR DESCRIPTION
## 🚀 Work Description
- [x] 관리자용 api 분리
- [x] 공공 데이터 호출 api, 뉴스 크롤링 api는 관리자로 접근해야 실행되도록 했습니다. 

<br/>

## 🙇🏻‍♀️ To Reviewer
- 얌파일에 jwt > admin-secret에 있는 키값을 /api/admin/login 에 입력하고 발급받은 토큰 값으로 api 실행하면 됩니다! 

<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자 로그인을 위한 엔드포인트가 추가되어, 인증된 관리자는 별도의 토큰을 발급받을 수 있습니다.
  * 관리자 전용 요청에 대해 접근 권한을 확인하는 인터셉터가 도입되었습니다.

* **버그 수정**
  * 없음

* **기타**
  * JWT 토큰의 역할(Role) 처리 방식이 개선되어, 관리자와 일반 사용자 권한이 명확히 구분됩니다.
  * 보안 설정이 변경되어 관리자 로그인 엔드포인트만 비인가 접근이 허용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->