### PR TITLE
[Feat] 전화번호 사기분석 API

### DIFF
--- a/src/main/java/com/blockguard/server/domain/fraud/api/FraudApi.java
+++ b/src/main/java/com/blockguard/server/domain/fraud/api/FraudApi.java
@@ -1,10 +1,13 @@
 package com.blockguard.server.domain.fraud.api;
 
 import com.blockguard.server.domain.fraud.application.FraudService;
+import com.blockguard.server.domain.fraud.dto.request.FraudPhoneNumberRequest;
 import com.blockguard.server.domain.fraud.dto.request.FraudUrlRequest;
-import com.blockguard.server.domain.fraud.dto.response.FraudUrlResponse;
+import com.blockguard.server.domain.fraud.dto.response.FraudRiskLevelResponse;
 import com.blockguard.server.global.common.codes.SuccessCode;
 import com.blockguard.server.global.common.response.BaseResponse;
+import com.blockguard.server.global.config.swagger.CustomExceptionDescription;
+import com.blockguard.server.global.config.swagger.SwaggerResponseDescription;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -21,9 +24,17 @@ public class FraudApi {
 
     @PostMapping("/url")
     @Operation(summary = "입력된 url 사기 분석")
-    public BaseResponse<FraudUrlResponse> fraudUrl(@Valid @RequestBody FraudUrlRequest fraudUrlRequest){
-        FraudUrlResponse fraudUrlResponse = fraudService.checkFraudUrl(fraudUrlRequest);
-        return BaseResponse.of(SuccessCode.CHECK_URL_FRAUD_SUCCESS, fraudUrlResponse);
+    public BaseResponse<FraudRiskLevelResponse> fraudUrl(@Valid @RequestBody FraudUrlRequest fraudUrlRequest){
+        FraudRiskLevelResponse fraudRiskLevelResponse = fraudService.checkFraudUrl(fraudUrlRequest);
+        return BaseResponse.of(SuccessCode.CHECK_URL_FRAUD_SUCCESS, fraudRiskLevelResponse);
+    }
+
+    @PostMapping("/number")
+    @CustomExceptionDescription(SwaggerResponseDescription.CHECK_FRAUD_PHONE_NUMBER_FAIL)
+    @Operation(summary = "입력된 전화번호 사기 분석")
+    public BaseResponse<FraudRiskLevelResponse> fraudPhoneNumber(@Valid @RequestBody FraudPhoneNumberRequest fraudPhoneNumberRequest){
+        FraudRiskLevelResponse fraudRiskLevelResponse = fraudService.checkFraudPhoneNumber(fraudPhoneNumberRequest);
+        return BaseResponse.of(SuccessCode.CHECK_PHONE_NUMBER_FRAUD_SUCCESS, fraudRiskLevelResponse);
     }
 
 }

--- a/src/main/java/com/blockguard/server/domain/fraud/api/FraudApi.java
+++ b/src/main/java/com/blockguard/server/domain/fraud/api/FraudApi.java
@@ -31,7 +31,7 @@ public class FraudApi {
 
     @PostMapping("/number")
     @CustomExceptionDescription(SwaggerResponseDescription.CHECK_FRAUD_PHONE_NUMBER_FAIL)
-    @Operation(summary = "입력된 전화번호 사기 분석")
+    @Operation(summary = "입력된 전화번호 사기 분석", description = "전화번호의 입력 형식 상관없음")
     public BaseResponse<FraudRiskLevelResponse> fraudPhoneNumber(@Valid @RequestBody FraudPhoneNumberRequest fraudPhoneNumberRequest){
         FraudRiskLevelResponse fraudRiskLevelResponse = fraudService.checkFraudPhoneNumber(fraudPhoneNumberRequest);
         return BaseResponse.of(SuccessCode.CHECK_PHONE_NUMBER_FRAUD_SUCCESS, fraudRiskLevelResponse);

--- a/src/main/java/com/blockguard/server/domain/fraud/application/FraudService.java
+++ b/src/main/java/com/blockguard/server/domain/fraud/application/FraudService.java
@@ -47,7 +47,7 @@ public class FraudService {
     }
 
     public FraudRiskLevelResponse checkFraudPhoneNumber(FraudPhoneNumberRequest fraudPhoneNumberRequest) {
-        String phoneNumber = fraudPhoneNumberRequest.getPhoneNumber().replaceAll("\\D", "");
+        String phoneNumber = fraudPhoneNumberRequest.getPhoneNumber().replaceAll("\\s+", "");
 
         // 사기 전화번호 조회 api 호출
         String spamCount = fraudNumberClient.checkSpamNumber(phoneNumber).getSpamCount();
@@ -64,6 +64,7 @@ public class FraudService {
     }
 
     private Boolean isFraudNumber(String spamCount) {
+        // spam count 최대 "1000+" 가 나오는 경우 고려
         return Integer.parseInt(spamCount.replaceAll("\\D+", "")) > 0;
     }
 }

--- a/src/main/java/com/blockguard/server/domain/fraud/application/FraudService.java
+++ b/src/main/java/com/blockguard/server/domain/fraud/application/FraudService.java
@@ -2,11 +2,13 @@ package com.blockguard.server.domain.fraud.application;
 
 import com.blockguard.server.domain.analysis.domain.enums.RiskLevel;
 import com.blockguard.server.domain.fraud.dao.FraudUrlRepository;
+import com.blockguard.server.domain.fraud.dto.request.FraudPhoneNumberRequest;
 import com.blockguard.server.domain.fraud.dto.request.FraudUrlRequest;
-import com.blockguard.server.domain.fraud.dto.response.FraudUrlResponse;
+import com.blockguard.server.domain.fraud.dto.response.FraudRiskLevelResponse;
 import com.blockguard.server.global.common.codes.ErrorCode;
 import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import com.blockguard.server.infra.google.GoogleSafeBrowsingClient;
+import com.blockguard.server.infra.number.FraudNumberClient;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,8 +17,9 @@ import org.springframework.stereotype.Service;
 public class FraudService {
     private final FraudUrlRepository fraudUrlRepository;
     private final GoogleSafeBrowsingClient googleSafeBrowsingService;
+    private final FraudNumberClient fraudNumberClient;
 
-    public FraudUrlResponse checkFraudUrl(FraudUrlRequest fraudUrlRequest) {
+    public FraudRiskLevelResponse checkFraudUrl(FraudUrlRequest fraudUrlRequest) {
         String url = fraudUrlRequest.getUrl();
 
         if (url == null || url.trim().isEmpty()){
@@ -25,7 +28,7 @@ public class FraudService {
 
         // 1차: DB 검사
         if(fraudUrlRepository.existsByUrl(url)){
-            return FraudUrlResponse.builder()
+            return FraudRiskLevelResponse.builder()
                     .riskLevel(RiskLevel.Dangers)
                     .build();
         }
@@ -33,13 +36,34 @@ public class FraudService {
         // 2차: Google Safe Browsing API 호출
         boolean isSafe = googleSafeBrowsingService.isUrlSafe(url);
         if (!isSafe){
-            return FraudUrlResponse.builder()
+            return FraudRiskLevelResponse.builder()
                     .riskLevel(RiskLevel.Dangers)
                     .build();
         }
 
-        return FraudUrlResponse.builder()
+        return FraudRiskLevelResponse.builder()
                 .riskLevel(RiskLevel.Safety)
                 .build();
+    }
+
+    public FraudRiskLevelResponse checkFraudPhoneNumber(FraudPhoneNumberRequest fraudPhoneNumberRequest) {
+        String phoneNumber = fraudPhoneNumberRequest.getPhoneNumber().replaceAll("\\D", "");
+
+        // 사기 전화번호 조회 api 호출
+        String spamCount = fraudNumberClient.checkSpamNumber(phoneNumber).getSpamCount();
+
+        if (isFraudNumber(spamCount)){
+            return FraudRiskLevelResponse.builder()
+                    .riskLevel(RiskLevel.Dangers)
+                    .build();
+        }
+
+        return FraudRiskLevelResponse.builder()
+                .riskLevel(RiskLevel.Safety)
+                .build();
+    }
+
+    private Boolean isFraudNumber(String spamCount) {
+        return Integer.parseInt(spamCount.replaceAll("\\D+", "")) > 0;
     }
 }

--- a/src/main/java/com/blockguard/server/domain/fraud/application/FraudService.java
+++ b/src/main/java/com/blockguard/server/domain/fraud/application/FraudService.java
@@ -10,8 +10,10 @@ import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import com.blockguard.server.infra.google.GoogleSafeBrowsingClient;
 import com.blockguard.server.infra.number.FraudNumberClient;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @AllArgsConstructor
 public class FraudService {
@@ -64,7 +66,16 @@ public class FraudService {
     }
 
     private Boolean isFraudNumber(String spamCount) {
-        // spam count 최대 "1000+" 가 나오는 경우 고려
-        return Integer.parseInt(spamCount.replaceAll("\\D+", "")) > 0;
+        try {
+            // spam count 최대 "1000+" 가 나오는 경우 고려
+            String numericPart = spamCount.replaceAll("\\D+", "");
+            if (numericPart.isEmpty()){
+                throw new BusinessExceptionHandler(ErrorCode.FRAUD_NUMBER_SERVER_ERROR);
+            }
+            return Integer.parseInt(numericPart) > 0;
+        } catch (NumberFormatException e) {
+            log.error("Invalid spam count format: {}", spamCount, e);
+            throw new BusinessExceptionHandler(ErrorCode.FRAUD_NUMBER_SERVER_ERROR);
+        }
     }
 }

--- a/src/main/java/com/blockguard/server/domain/fraud/dto/request/FraudPhoneNumberRequest.java
+++ b/src/main/java/com/blockguard/server/domain/fraud/dto/request/FraudPhoneNumberRequest.java
@@ -1,0 +1,15 @@
+package com.blockguard.server.domain.fraud.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FraudPhoneNumberRequest {
+    // Todo: 전화번호 형식 논의 후 수정 -> 국제 번호 또는 지역 번호 고려
+    @NotBlank
+    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "phoneNumber must match 010-1234-5678 format")
+    private String phoneNumber;
+}

--- a/src/main/java/com/blockguard/server/domain/fraud/dto/request/FraudPhoneNumberRequest.java
+++ b/src/main/java/com/blockguard/server/domain/fraud/dto/request/FraudPhoneNumberRequest.java
@@ -1,6 +1,7 @@
 package com.blockguard.server.domain.fraud.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,5 +9,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class FraudPhoneNumberRequest {
     @NotBlank
+    @Size(max = 20)
     private String phoneNumber;
 }

--- a/src/main/java/com/blockguard/server/domain/fraud/dto/request/FraudPhoneNumberRequest.java
+++ b/src/main/java/com/blockguard/server/domain/fraud/dto/request/FraudPhoneNumberRequest.java
@@ -1,15 +1,12 @@
 package com.blockguard.server.domain.fraud.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class FraudPhoneNumberRequest {
-    // Todo: 전화번호 형식 논의 후 수정 -> 국제 번호 또는 지역 번호 고려
     @NotBlank
-    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "phoneNumber must match 010-1234-5678 format")
     private String phoneNumber;
 }

--- a/src/main/java/com/blockguard/server/domain/fraud/dto/response/FraudRiskLevelResponse.java
+++ b/src/main/java/com/blockguard/server/domain/fraud/dto/response/FraudRiskLevelResponse.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class FraudUrlResponse {
+public class FraudRiskLevelResponse {
     private RiskLevel riskLevel;
 }

--- a/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/ErrorCode.java
@@ -32,7 +32,8 @@ public enum ErrorCode {
 
     // 5000~ : server error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 오류가 발생했습니다."),
-    AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "AI 서버와의 통신 오류가 발생했습니다.");
+    AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "AI 서버와의 통신 오류가 발생했습니다."),
+    FRAUD_NUMBER_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "사기 전화번호 제공 서버와의 통신 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/blockguard/server/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((registry) ->
                         registry
                                 .requestMatchers("/api/auth/**").permitAll()   // 로그인/회원가입만 허용
-                                .requestMatchers("/api/admin/update/fraud-url", "/api/fraud/url", "/api/fraud-analysis").permitAll()
+                                .requestMatchers("/api/admin/update/fraud-url", "/api/fraud/url", "/api/fraud/number", "/api/fraud-analysis").permitAll()
                                 .requestMatchers("/actuator/health").permitAll() // 헬스체크 허용
                                 .requestMatchers("/", "/index.html", "/favicon.ico").permitAll()
                                 .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**", "/webjars/**").permitAll()

--- a/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
@@ -81,6 +81,10 @@ public enum SwaggerResponseDescription {
             ErrorCode.INVALID_EMAIL_TYPE
     ))),
 
+    CHECK_FRAUD_PHONE_NUMBER_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.FRAUD_NUMBER_SERVER_ERROR
+    ))),
+
     INVALID_TOKEN(new LinkedHashSet<>(Set.of(
             ErrorCode.INVALID_TOKEN
     )));

--- a/src/main/java/com/blockguard/server/infra/number/CheckFraudNumberResponse.java
+++ b/src/main/java/com/blockguard/server/infra/number/CheckFraudNumberResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class CheckSpamNumberResponse {
+public class CheckFraudNumberResponse {
     private DataBlock data;
     private ApiBlock api;
 

--- a/src/main/java/com/blockguard/server/infra/number/CheckSpamNumberResponse.java
+++ b/src/main/java/com/blockguard/server/infra/number/CheckSpamNumberResponse.java
@@ -1,0 +1,43 @@
+package com.blockguard.server.infra.number;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CheckSpamNumberResponse {
+    private DataBlock data;
+    private ApiBlock api;
+
+    @Getter
+    @Builder
+    public static class DataBlock {
+        private String number;
+        private String spam;
+
+        @JsonProperty("spam_count")
+        private String spamCount;
+
+        @JsonProperty("registed_date")
+        private String registedDate;
+
+        @JsonProperty("cyber_crime")
+        private String cyberCrime;
+
+        /** 1=성공, 0=실패, 3: 실패(timeout) */
+        private int success;
+    }
+
+    @Getter
+    @Builder
+    public static class ApiBlock {
+        private boolean success;
+        private int cost;
+        private int ms;
+
+        @JsonProperty("pl_id")
+        private int plId;
+    }
+
+}

--- a/src/main/java/com/blockguard/server/infra/number/FraudNumberClient.java
+++ b/src/main/java/com/blockguard/server/infra/number/FraudNumberClient.java
@@ -33,7 +33,7 @@ public class FraudNumberClient {
      * @return CheckSpamNumberResponse.DataBlock
      */
     // Todo: 국제번호의 + 가능한지 체크
-    public CheckSpamNumberResponse.DataBlock checkSpamNumber(String number){
+    public CheckFraudNumberResponse.DataBlock checkSpamNumber(String number){
         HttpHeaders headers = new HttpHeaders();
         headers.add("CL_AUTH_KEY", apiKey);
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
@@ -44,18 +44,18 @@ public class FraudNumberClient {
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
 
         try{
-            ResponseEntity<CheckSpamNumberResponse> response =
+            ResponseEntity<CheckFraudNumberResponse> response =
                     restTemplate.postForEntity(
                             apiUrl,
                             request,
-                            CheckSpamNumberResponse.class
+                            CheckFraudNumberResponse.class
                     );
             if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
                 log.error("FraudNumber API error: status={}, body={}", response.getStatusCode(), response.getBody());
                 throw new BusinessExceptionHandler(ErrorCode.FRAUD_NUMBER_SERVER_ERROR);
             }
 
-            CheckSpamNumberResponse.DataBlock data = response.getBody().getData();
+            CheckFraudNumberResponse.DataBlock data = response.getBody().getData();
             if (data.getSuccess() != 1) {
                 log.warn("SpamNumber API returned success!=1: {}", data);
             }

--- a/src/main/java/com/blockguard/server/infra/number/FraudNumberClient.java
+++ b/src/main/java/com/blockguard/server/infra/number/FraudNumberClient.java
@@ -1,0 +1,70 @@
+package com.blockguard.server.infra.number;
+
+import com.blockguard.server.global.common.codes.ErrorCode;
+import com.blockguard.server.global.exception.BusinessExceptionHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FraudNumberClient {
+    private final RestTemplate restTemplate;
+
+    @Value("${fraud.number.api.invoke-url}")
+    private String apiUrl;
+
+    @Value("${fraud.number.api.secret-key}")
+    private String apiKey;
+
+    /**
+     * 주어진 번호에 대해 스팸 여부를 조회합니다.
+     * @param number "-" 없이 숫자만 이어 붙인 폰번호(ex: "01012341234")
+     * @return CheckSpamNumberResponse.DataBlock
+     */
+    public CheckSpamNumberResponse.DataBlock checkSpamNumber(String number){
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("CL_AUTH_KEY", apiKey);
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("number", number);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        try{
+            ResponseEntity<CheckSpamNumberResponse> response =
+                    restTemplate.postForEntity(
+                            apiUrl,
+                            request,
+                            CheckSpamNumberResponse.class
+                    );
+            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+                log.error("FraudNumber API error: status={}, body={}", response.getStatusCode(), response.getBody());
+                throw new BusinessExceptionHandler(ErrorCode.FRAUD_NUMBER_SERVER_ERROR);
+            }
+
+            CheckSpamNumberResponse.DataBlock data = response.getBody().getData();
+            if (data.getSuccess() != 1) {
+                log.warn("SpamNumber API returned success!=1: {}", data);
+            }
+
+            return data;
+
+        } catch (RestClientException ex){
+            log.error("Failed to call FraudNumber API", ex);
+            throw new BusinessExceptionHandler(ErrorCode.FRAUD_NUMBER_SERVER_ERROR);
+        }
+    }
+
+}

--- a/src/main/java/com/blockguard/server/infra/number/FraudNumberClient.java
+++ b/src/main/java/com/blockguard/server/infra/number/FraudNumberClient.java
@@ -32,6 +32,7 @@ public class FraudNumberClient {
      * @param number "-" 없이 숫자만 이어 붙인 폰번호(ex: "01012341234")
      * @return CheckSpamNumberResponse.DataBlock
      */
+    // Todo: 국제번호의 + 가능한지 체크
     public CheckSpamNumberResponse.DataBlock checkSpamNumber(String number){
         HttpHeaders headers = new HttpHeaders();
         headers.add("CL_AUTH_KEY", apiKey);


### PR DESCRIPTION
## 💻 Related Issue
closed #41 
<br/>

## 🚀 Work Description
- [x] 전화번호 사기분석 API
<img width="1142" height="490" alt="스크린샷 2025-08-04 01 24 44" src="https://github.com/user-attachments/assets/02b1a760-a1fc-471b-891c-e8d0f2b02886" />

<br/>

## 🙇🏻‍♀️ To Reviewer
- 요청 바디인 전화번호에 제약조건은 NotBlank 하나만 걸었습니다!
- 에이픽 전화번호 api는 국제번호랑 지역번호 등 요청으로 보내는 전화번호 형식에 관계없이 잘 작동하길래 전화번호 사기분석 요청 바디도 제약조건 없이 받도록 했습니다! ("010-1234-1234", "+82-1234-1234", "01012341234" 다 허용)

<br/>

## ➕ Next
- 사기 분석 설문에서 의심가는 url, 전화번호 입력이 있으면 검증 및 가산점 부여 로직 추가

 <br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 전화번호의 사기 위험도를 분석하는 새로운 엔드포인트가 추가되었습니다.
  * URL 및 전화번호 사기 위험도 분석 결과가 통합된 응답 형식으로 제공됩니다.

* **버그 수정**
  * 사기 전화번호 제공 서버와의 통신 오류에 대한 에러 코드 및 안내 메시지가 추가되었습니다.

* **문서화**
  * Swagger 문서에 전화번호 사기 위험도 분석 관련 설명과 예외 정보가 반영되었습니다.

* **보안**
  * 전화번호 사기 위험도 분석 엔드포인트가 인증 없이 접근 가능하도록 허용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->