### PR TITLE
[Feat] 주요 뉴스 조회 API

### DIFF
--- a/src/main/java/com/blockguard/server/domain/news/api/NewsApi.java
+++ b/src/main/java/com/blockguard/server/domain/news/api/NewsApi.java
@@ -1,6 +1,7 @@
 package com.blockguard.server.domain.news.api;
 
 import com.blockguard.server.domain.news.application.NewsService;
+import com.blockguard.server.domain.news.dto.response.NewsArticleResponse;
 import com.blockguard.server.domain.news.dto.response.NewsPageResponse;
 import com.blockguard.server.global.common.codes.SuccessCode;
 import com.blockguard.server.global.common.response.BaseResponse;
@@ -10,6 +11,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/news")
@@ -28,6 +31,13 @@ public class NewsApi {
             @RequestParam(defaultValue = "전체") String category) {
         NewsPageResponse newsPageResponse = newsService.getNewsList(page, size, sort, category);
         return BaseResponse.of(SuccessCode.GET_NEWS_ARTICLES_SUCCESS, newsPageResponse);
+    }
+
+    @GetMapping("/selected")
+    @Operation(summary = "주요 뉴스 조회")
+    public BaseResponse<List<NewsArticleResponse>> getSelectedArticles(){
+        List<NewsArticleResponse> selectedArticles = newsService.getSelectedArticles();
+        return BaseResponse.of(SuccessCode.GET_SELECTED_NEWS_SUCCESS, selectedArticles);
     }
 
 }

--- a/src/main/java/com/blockguard/server/domain/news/api/NewsApi.java
+++ b/src/main/java/com/blockguard/server/domain/news/api/NewsApi.java
@@ -34,6 +34,7 @@ public class NewsApi {
     }
 
     @GetMapping("/selected")
+    @CustomExceptionDescription(SwaggerResponseDescription.GET_NEWS_ARTICLES_FAIL)
     @Operation(summary = "주요 뉴스 조회")
     public BaseResponse<List<NewsArticleResponse>> getSelectedArticles(){
         List<NewsArticleResponse> selectedArticles = newsService.getSelectedArticles();

--- a/src/main/java/com/blockguard/server/domain/news/application/NewsService.java
+++ b/src/main/java/com/blockguard/server/domain/news/application/NewsService.java
@@ -64,4 +64,11 @@ public class NewsService {
     }
 
 
+    public List<NewsArticleResponse> getSelectedArticles() {
+        List<Long> selectedIds = List.of(1L, 2L, 3L, 4L, 5L, 6L);
+        List<NewsArticle> articles = newsRepository.findAllById(selectedIds);
+
+        return articles.stream().map(NewsArticleResponse::from)
+                .toList();
+    }
 }

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -33,7 +33,8 @@ public enum SuccessCode {
     UPDATE_STEP_INFO_SUCCESS(HttpStatus.OK,2022, "신고 단계 정보가 성공적으로 업데이트 되었습니다."),
     GET_NEWS_ARTICLES_SUCCESS(HttpStatus.OK, 2023, "뉴스 목록 조회가 완료되었습니다."),
     CRWAL_DAUM_NEWS_SUCCESS(HttpStatus.OK, 2024, "뉴스 크롤링이 완료되었습니다."),
-    ADMIN_TOKEN_SUCCESS(HttpStatus.OK, 2025, "관리자 토큰이 발급되었습니다.");
+    ADMIN_TOKEN_SUCCESS(HttpStatus.OK, 2025, "관리자 토큰이 발급되었습니다."),
+    GET_SELECTED_NEWS_SUCCESS(HttpStatus.OK, 2026, "선택된 주요 뉴스 6개가 조회 완료되었습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/blockguard/server/global/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/auth/**").permitAll()   // 로그인 및 회원가입
                                 .requestMatchers("/api/admin/login").permitAll()   // 관리자 로그인
                                 .requestMatchers("/api/fraud/url", "/api/fraud/number","/api/fraud-analysis").permitAll() // 사기 분석
-                                .requestMatchers("/api/news").permitAll() // 뉴스 조회
+                                .requestMatchers("/api/news","/api/news/selected").permitAll() // 뉴스 조회
                                 .requestMatchers("/actuator/health").permitAll() // 헬스체크 허용
                                 .requestMatchers("/", "/index.html", "/favicon.ico").permitAll()
                                 .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**", "/webjars/**").permitAll()


### PR DESCRIPTION
## 💻 Related Issue
close #51 

<br/>

## 🚀 Work Description
- [x] 뉴스 페이지 상단에 있는 주요 뉴스 조회 API를 구현하였습니다.
<img width="2092" height="1040" alt="image" src="https://github.com/user-attachments/assets/186b5ea7-054e-4e6a-ae5d-c0078d9c658c" />
추후 PM분이 지정한 뉴스로 수정할 계획입니다.

<br/>

## 🙇🏻‍♀️ To Reviewer
회의에서 주간 뉴스 조회와 최신 뉴스 조회의 경계가 애매하여 논의한 끝에, 주간 뉴스 조회를 주요 뉴스 조회로 관리자가 선정한 6개의 뉴스를 띄우기로 했습니다. 현재는 관리자 페이지 구현이 어려워서 서버에서 지정하여 프론트로 보내는 방식으로 구현하였습니다.
추후 2차 구현이나 리팩토링 시에 구현 방식이 바뀔 수도 있습니다.

<br/>

## ➕ Next
- gpt ai 점수화 로직 마무리

 <br/>
