### PR TITLE
[Feat] 사기분석 api : url/전화번호 추가점수 로직 구현

### DIFF
--- a/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
@@ -10,6 +10,8 @@ import com.blockguard.server.global.common.codes.SuccessCode;
 import com.blockguard.server.global.common.response.BaseResponse;
 import com.blockguard.server.global.config.resolver.CurrentUser;
 import com.blockguard.server.global.config.resolver.OptionalUser;
+import com.blockguard.server.global.config.swagger.CustomExceptionDescription;
+import com.blockguard.server.global.config.swagger.SwaggerResponseDescription;
 import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,6 +33,7 @@ public class FraudAnalysisApi {
     private final ObjectMapper objectMapper;
 
     @PostMapping(value = "/fraud-analysis", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @CustomExceptionDescription(SwaggerResponseDescription.ANALYZE_FRAUD_FAIL)
     @Operation(summary = "사기 분석")
     public BaseResponse<FraudAnalysisResponse> analyzeFraud(
             @RequestParam("fraudAnalysisRequest") String jsonStr,
@@ -49,6 +52,7 @@ public class FraudAnalysisApi {
     }
 
     @GetMapping(value = "/fraud-analysis")
+    @CustomExceptionDescription(SwaggerResponseDescription.INVALID_TOKEN)
     @Operation(summary = "사기 분석 기록 조회")
     public BaseResponse<List<FraudAnalysisRecordResponse>> getAnalyzeFraudList(@Parameter(hidden = true) @CurrentUser User user){
         List<FraudAnalysisRecordResponse> fraudAnalysisRecordResponse = fraudAnalysisService.getAnalyzeFraudList(user);

--- a/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
@@ -2,17 +2,20 @@ package com.blockguard.server.domain.analysis.api;
 
 import com.blockguard.server.domain.analysis.application.FraudAnalysisService;
 import com.blockguard.server.domain.analysis.dto.request.FraudAnalysisRequest;
+import com.blockguard.server.domain.analysis.dto.response.FraudAnalysisRecordResponse;
 import com.blockguard.server.domain.analysis.dto.response.FraudAnalysisResponse;
+import com.blockguard.server.domain.user.domain.User;
 import com.blockguard.server.global.common.codes.ErrorCode;
 import com.blockguard.server.global.common.codes.SuccessCode;
 import com.blockguard.server.global.common.response.BaseResponse;
+import com.blockguard.server.global.config.resolver.CurrentUser;
 import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -41,5 +44,12 @@ public class FraudAnalysisApi {
         FraudAnalysisRequest request = objectMapper.readValue(jsonStr, FraudAnalysisRequest.class);
         FraudAnalysisResponse fraudAnalysisResponse = fraudAnalysisService.fraudAnalysis(request, imageFiles);
         return BaseResponse.of(SuccessCode.ANALYZE_FRAUD_SUCCESS, fraudAnalysisResponse);
+    }
+
+    @GetMapping(value = "/fraud-analysis")
+    @Operation(summary = "사기 분석 기록 조회")
+    public BaseResponse<List<FraudAnalysisRecordResponse>> getAnalyzeFraudList(@Parameter(hidden = true) @CurrentUser User user){
+        List<FraudAnalysisRecordResponse> fraudAnalysisRecordResponse = fraudAnalysisService.getAnalyzeFraudList(user);
+        return BaseResponse.of(SuccessCode.GET_ANALYZE_FRAUD_LIST_SUCCESS, fraudAnalysisRecordResponse);
     }
 }

--- a/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/api/FraudAnalysisApi.java
@@ -9,6 +9,7 @@ import com.blockguard.server.global.common.codes.ErrorCode;
 import com.blockguard.server.global.common.codes.SuccessCode;
 import com.blockguard.server.global.common.response.BaseResponse;
 import com.blockguard.server.global.config.resolver.CurrentUser;
+import com.blockguard.server.global.config.resolver.OptionalUser;
 import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,10 +32,11 @@ public class FraudAnalysisApi {
 
     @PostMapping(value = "/fraud-analysis", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "사기 분석")
-    public BaseResponse<FraudAnalysisResponse> analyzeFraud
-            (@RequestParam("fraudAnalysisRequest") String jsonStr,
-             @RequestParam(value = "imageFiles", required = false) List<MultipartFile> imageFiles
-            ) throws JsonProcessingException {
+    public BaseResponse<FraudAnalysisResponse> analyzeFraud(
+            @RequestParam("fraudAnalysisRequest") String jsonStr,
+             @RequestParam(value = "imageFiles", required = false) List<MultipartFile> imageFiles,
+            @Parameter(hidden = true) @OptionalUser User user
+    ) throws JsonProcessingException {
 
         // TODO: 이미지 파일 개수 픽스 필요
         if (imageFiles != null && imageFiles.size() > 2) {
@@ -42,7 +44,7 @@ public class FraudAnalysisApi {
         }
 
         FraudAnalysisRequest request = objectMapper.readValue(jsonStr, FraudAnalysisRequest.class);
-        FraudAnalysisResponse fraudAnalysisResponse = fraudAnalysisService.fraudAnalysis(request, imageFiles);
+        FraudAnalysisResponse fraudAnalysisResponse = fraudAnalysisService.fraudAnalysis(request, imageFiles, user);
         return BaseResponse.of(SuccessCode.ANALYZE_FRAUD_SUCCESS, fraudAnalysisResponse);
     }
 

--- a/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
@@ -75,7 +75,7 @@ public class FraudAnalysisService {
         return FraudAnalysisResponse.builder()
                 .keywords(gptResponse.getKeywords())
                 .score(score)
-                .estimatedFraudType(gptResponse.getEstimatedFraudType())
+                .estimatedFraudType(fraudTypeEnum.getKorName())
                 .explanation(gptResponse.getExplanation())
                 .riskLevel(riskLevel.getValue())
                 .build();

--- a/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
@@ -83,12 +83,12 @@ public class FraudAnalysisService {
 
     private double addFraudPhoneNumberScore(FraudAnalysisRequest fraudAnalysisRequest, double score) {
         if (StringUtils.hasText(fraudAnalysisRequest.getSuspiciousPhoneNumbers())) {
-            // 전화번호 위험이면 score 15점 추가
+            // 전화번호 위험이면 score 10점 추가
             String number = fraudAnalysisRequest.getSuspiciousPhoneNumbers().replaceAll("\\D+", "");
             if (!number.isEmpty() &&
                     fraudService.checkFraudPhoneNumber(new FraudPhoneNumberRequest(number))
                             .getRiskLevel() == RiskLevel.Dangers){
-                score += 15;
+                score += 10;
             }
         }
         return score;
@@ -96,12 +96,12 @@ public class FraudAnalysisService {
 
     private double addFraudUrlScore(FraudAnalysisRequest fraudAnalysisRequest, double score) {
         if (StringUtils.hasText(fraudAnalysisRequest.getSuspiciousLinks())) {
-            // 링크 위험이면 score 15점 추가
+            // 링크 위험이면 score 10점 추가
             String link = fraudAnalysisRequest.getSuspiciousLinks().trim();
             if (!link.isEmpty() &&
                     fraudService.checkFraudUrl(new FraudUrlRequest(link))
                             .getRiskLevel() == RiskLevel.Dangers) {
-                score += 15;
+                score += 10;
             }
         }
         return score;
@@ -127,19 +127,27 @@ public class FraudAnalysisService {
         return String.join(" ", imageContents);
     }
 
-    private static void extractKeywordsFromRequest(FraudAnalysisRequest fraudAnalysisRequest, List<String> keywords) {
-        if (StringUtils.hasText(fraudAnalysisRequest.getContactMethod()))
-            keywords.add(fraudAnalysisRequest.getContactMethod());
-        if (StringUtils.hasText(fraudAnalysisRequest.getCounterpart()))
-            keywords.add(fraudAnalysisRequest.getCounterpart());
-        if (fraudAnalysisRequest.getRequestedAction() != null && !fraudAnalysisRequest.getRequestedAction().isEmpty())
-            keywords.addAll(fraudAnalysisRequest.getRequestedAction());
-        if (fraudAnalysisRequest.getRequestedInfo() != null && !fraudAnalysisRequest.getRequestedInfo().isEmpty())
-            keywords.addAll(fraudAnalysisRequest.getRequestedInfo());
-        if (StringUtils.hasText(fraudAnalysisRequest.getAppType()))
-            keywords.add(fraudAnalysisRequest.getAppType());
-        if (fraudAnalysisRequest.getAtmGuided())
-            keywords.add("긴급성이나 위기감을 느끼게 하는 표현이 있었다");
+    private static void extractKeywordsFromRequest(FraudAnalysisRequest request, List<String> keywords) {
+        if (StringUtils.hasText(request.getContactMethod()))
+            keywords.add(request.getContactMethod());
+        if (StringUtils.hasText(request.getCounterpart()))
+            keywords.add(request.getCounterpart());
+        if (request.getRequestedAction() != null && !request.getRequestedAction().isEmpty())
+            keywords.addAll(request.getRequestedAction());
+        if (request.getRequestedInfo() != null && !request.getRequestedInfo().isEmpty())
+            keywords.addAll(request.getRequestedInfo());
+        if (StringUtils.hasText(request.getLinkType()))
+            keywords.add(request.getLinkType());
+        if (Boolean.TRUE.equals(request.getPressuredInfo()))
+            keywords.add("개인정보 유출/범죄 연루 언급 등 심리적 압박");
+        if (Boolean.TRUE.equals(request.getAppOrLinkRequest()))
+            keywords.add("앱 설치/링크 접속 유도");
+        if (Boolean.TRUE.equals(request.getThirdPartyConnect()))
+            keywords.add("제3자(수사관 등) 연결 시도");
+        if (Boolean.TRUE.equals(request.getAuthorityPressure()))
+            keywords.add("직책 강조 및 권위적 태도 보임");
+        if (Boolean.TRUE.equals(request.getAccountOrLinkRequest()))
+            keywords.add("계좌이체/현금인출 유도");
     }
 
     private static GptRequest buildGptRequest(FraudAnalysisRequest fraudAnalysisRequest, List<String> keywords, String additionalDescription, String imageContent) {

--- a/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
@@ -47,7 +47,7 @@ public class FraudAnalysisService {
         // ai 서버 호출
         GptResponse gptResponse = gptApiClient.analyze(gptRequest);
 
-        score += gptResponse.getScore();
+        score = Math.min(100, score + gptResponse.getScore());
         return FraudAnalysisResponse.builder()
                 .keywords(gptResponse.getKeywords())
                 .score(score)

--- a/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
@@ -33,10 +33,10 @@ public class FraudAnalysisService {
         List<String> keywords = new ArrayList<>();
         double score = 0;
 
-        extractKeywordsFromRequest(fraudAnalysisRequest, keywords);
-
         score = addFraudUrlScore(fraudAnalysisRequest, score);
         score = addFraudPhoneNumberScore(fraudAnalysisRequest, score);
+
+        extractKeywordsFromRequest(fraudAnalysisRequest, keywords);
 
         String additionalDescription = fraudAnalysisRequest.getAdditionalDescription();
         String imageContent = "";
@@ -50,7 +50,7 @@ public class FraudAnalysisService {
         score += gptResponse.getScore();
         return FraudAnalysisResponse.builder()
                 .keywords(gptResponse.getKeywords())
-                .score(gptResponse.getScore())
+                .score(score)
                 .estimatedFraudType(gptResponse.getEstimatedFraudType())
                 .explanation(gptResponse.getExplanation())
                 .riskLevel(RiskLevel.fromScore(score).getValue())
@@ -61,7 +61,7 @@ public class FraudAnalysisService {
         if (StringUtils.hasText(fraudAnalysisRequest.getSuspiciousPhoneNumbers())) {
             // 전화번호 위험이면 score 15점 추가
             String number = fraudAnalysisRequest.getSuspiciousPhoneNumbers().replaceAll("\\D+", "");
-            if (number.isEmpty() &&
+            if (!number.isEmpty() &&
                     fraudService.checkFraudPhoneNumber(new FraudPhoneNumberRequest(number))
                             .getRiskLevel() == RiskLevel.Dangers){
                 score += 15;

--- a/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/application/FraudAnalysisService.java
@@ -1,18 +1,22 @@
 package com.blockguard.server.domain.analysis.application;
 
+import com.blockguard.server.domain.analysis.dao.FraudAnalysisRecordRepository;
 import com.blockguard.server.domain.analysis.domain.enums.RiskLevel;
 import com.blockguard.server.domain.analysis.dto.request.FraudAnalysisRequest;
 import com.blockguard.server.domain.analysis.dto.request.GptRequest;
+import com.blockguard.server.domain.analysis.dto.response.FraudAnalysisRecordResponse;
 import com.blockguard.server.domain.analysis.dto.response.FraudAnalysisResponse;
 import com.blockguard.server.domain.analysis.dto.response.GptResponse;
 import com.blockguard.server.domain.fraud.application.FraudService;
 import com.blockguard.server.domain.fraud.dto.request.FraudPhoneNumberRequest;
 import com.blockguard.server.domain.fraud.dto.request.FraudUrlRequest;
+import com.blockguard.server.domain.user.domain.User;
 import com.blockguard.server.infra.gpt.GptApiClient;
 import com.blockguard.server.infra.naver.ocr.NaverOcrClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -28,7 +32,9 @@ public class FraudAnalysisService {
     private final NaverOcrClient naverOcrClient;
     private final GptApiClient gptApiClient;
     private final FraudService fraudService;
+    private final FraudAnalysisRecordRepository fraudAnalysisRecordRepository;
 
+    @Transactional
     public FraudAnalysisResponse fraudAnalysis(FraudAnalysisRequest fraudAnalysisRequest, List<MultipartFile> imageFiles) {
         List<String> keywords = new ArrayList<>();
         double score = 0;
@@ -125,5 +131,11 @@ public class FraudAnalysisService {
                 .messageContent(StringUtils.hasText(fraudAnalysisRequest.getMessageContent()) ? fraudAnalysisRequest.getMessageContent() : null)
                 .imageContent(StringUtils.hasText(imageContent) ? imageContent : null)
                 .build();
+    }
+
+    public List<FraudAnalysisRecordResponse> getAnalyzeFraudList(User user){
+        return fraudAnalysisRecordRepository.findAllByUserOrderByCreatedAtDesc(user).stream()
+                .map(FraudAnalysisRecordResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/blockguard/server/domain/analysis/dao/FraudAnalysisRecordRepository.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/dao/FraudAnalysisRecordRepository.java
@@ -1,0 +1,11 @@
+package com.blockguard.server.domain.analysis.dao;
+
+import com.blockguard.server.domain.analysis.domain.FraudAnalysisRecord;
+import com.blockguard.server.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FraudAnalysisRecordRepository extends JpaRepository<FraudAnalysisRecord, Long> {
+    List<FraudAnalysisRecord> findAllByUserOrderByCreatedAtDesc(User user);
+}

--- a/src/main/java/com/blockguard/server/domain/analysis/domain/FraudAnalysisRecord.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/domain/FraudAnalysisRecord.java
@@ -30,10 +30,10 @@ public class FraudAnalysisRecord extends BaseEntity {
     private BigDecimal score;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "estimated_fraud_type", nullable = false)
+    @Column(name = "estimated_fraud_type")
     private FraudType estimatedFraudType;
 
-    @Column(nullable = false, length = 255)
+    @Column(length = 255)
     private String keywords;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/blockguard/server/domain/analysis/domain/enums/FraudType.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/domain/enums/FraudType.java
@@ -5,27 +5,28 @@ import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import lombok.Getter;
 
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 @Getter
 public enum FraudType {
-    INSTITUTION_IMPERSONATION("기관사칭형"),
-    LOAN_FRAUD               ("대출사기형"),
+    INSTITUTION_IMPERSONATION("기관 사칭형"),
+    LOAN_FRAUD               ("대출 사기형"),
     CARD_COMPANY_IMPERSONATION("카드사 사칭형"),
-    FAMILY_IMPERSONATION      ("가족/지인사칭형"),
+    FAMILY_IMPERSONATION      ("가족/지인 사칭형"),
     FIRST_BIRTHDAY_INVITE     ("돌잔치 초대장형"),
     MOBILE_WEDDING_INVITE     ("모바일 청첩장형"),
-    OBITUARY_MESSAGE          ("부고문자형"),
+    OBITUARY_MESSAGE          ("부고 문자형"),
     FINE_AND_PENALTY          ("범칙금/과태료 부과형"),
     HEALTH_INSURANCE_IMPERSONATION("건강보험공단 사칭형"),
-    POLICE_SUMMONS            ("경찰출석요구형"),
+    POLICE_SUMMONS            ("경찰 출석 요구형"),
     NATIONAL_TAX_SERVICE      ("국세청 사칭형"),
     PART_TIME_SCAM            ("알바/부업 사기형"),
-    GOVERNMENT_GRANT_SCAM     ("정부지원금 위장형"),
-    DELIVERY_SCAM             ("택배사기형"),
+    GOVERNMENT_GRANT_SCAM     ("정부 지원금 위장형"),
+    DELIVERY_SCAM             ("택배 사기형"),
     CRYPTOCURRENCY_SCAM       ("가상화폐 사기형"),
     STOCK_INVESTMENT_SCAM     ("주식투자 사기형"),
     IPO_SCAM                  ("청약 공모주 사기형"),
-    FALSE_PAYMENT_SCAM        ("허위결제사기형");
+    FALSE_PAYMENT_SCAM        ("허위결제 사기형");
 
     private final String korName;
 
@@ -33,13 +34,21 @@ public enum FraudType {
         this.korName = korName;
     }
 
+    // 공백(ASCII/유니코드 구분자 포함) 전부 제거
+    private static final Pattern WS = Pattern.compile("[\\s\\p{Z}]+");
+
+    private static String squashSpaces(String s) {
+        return WS.matcher(s).replaceAll("");
+    }
+
     public static FraudType fromKoreanName(String kr) {
         if (kr == null) {
             throw new BusinessExceptionHandler(ErrorCode.AI_SERVER_ERROR);
         }
-        final String kor = kr.trim();
+        final String target = squashSpaces(kr.trim());
+
         return Arrays.stream(values())
-                .filter(e -> e.korName.equals(kor))
+                .filter(e -> squashSpaces(e.korName).equals(target))
                 .findFirst()
                 .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.AI_SERVER_ERROR));
     }

--- a/src/main/java/com/blockguard/server/domain/analysis/domain/enums/FraudType.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/domain/enums/FraudType.java
@@ -4,30 +4,24 @@ import lombok.Getter;
 
 @Getter
 public enum FraudType {
-    VOICE_PHISHING           ("보이스피싱"),
-    MESSENGER_PHISHING       ("메신저피싱"),
-    SMISHING                 ("스미싱"),
-    INSTITUTION_IMPERSONATION("기관사칭형"),
-    LOAN_FRAUD               ("대출사기형"),
-    CARD_COMPANY_IMPERSONATION("카드사 사칭형"),
-    FAMILY_IMPERSONATION      ("가족/지인사칭형"),
-    CELEBRATORY_IMPERSONATION("경조사사칭형"),
-    FIRST_BIRTHDAY_INVITE     ("돌잔치 초대장형"),
-    MOBILE_WEDDING_INVITE     ("모바일 청첩장형"),
-    OBITUARY_MESSAGE          ("부고문자형"),
-    PUBLIC_AGENCY_IMPERSONATION("공공기관 사칭형"),
-    FINE_AND_PENALTY          ("범칙금/과태료 부과형"),
-    HEALTH_INSURANCE_IMPERSONATION("건강보험공단 사칭형"),
-    POLICE_SUMMONS            ("경찰출석요구형"),
-    NATIONAL_TAX_SERVICE      ("국세청 사칭형"),
-    PART_TIME_SCAM            ("알바/부업 사기형"),
-    GOVERNMENT_GRANT_SCAM     ("정부지원금 위장형"),
-    DELIVERY_SCAM             ("택배사기형"),
-    INVESTMENT_SCAM           ("투자사기형"),
-    CRYPTOCURRENCY_SCAM       ("가상화폐 사기형"),
-    STOCK_INVESTMENT_SCAM     ("주식투자 사기형"),
-    IPO_SCAM                  ("청약 공모주 사기형"),
-    FALSE_PAYMENT_SCAM        ("허위결제사기형");
+    INSTITUTION_IMPERSONATION("보이스피싱_기관사칭형"),
+    LOAN_FRAUD               ("보이스피싱_대출사기형"),
+    CARD_COMPANY_IMPERSONATION("보이스피싱_카드사 사칭형"),
+    FAMILY_IMPERSONATION      ("메신저피싱_가족/지인사칭형"),
+    FIRST_BIRTHDAY_INVITE     ("스미싱_돌잔치 초대장형"),
+    MOBILE_WEDDING_INVITE     ("스미싱_모바일 청첩장형"),
+    OBITUARY_MESSAGE          ("스미싱_부고문자형"),
+    FINE_AND_PENALTY          ("스미싱_범칙금/과태료 부과형"),
+    HEALTH_INSURANCE_IMPERSONATION("스미싱_건강보험공단 사칭형"),
+    POLICE_SUMMONS            ("스미싱_경찰출석요구형"),
+    NATIONAL_TAX_SERVICE      ("스미싱_국세청 사칭형"),
+    PART_TIME_SCAM            ("스미싱_알바/부업 사기형"),
+    GOVERNMENT_GRANT_SCAM     ("스미싱_정부지원금 위장형"),
+    DELIVERY_SCAM             ("스미싱_택배사기형"),
+    CRYPTOCURRENCY_SCAM       ("스미싱_가상화폐 사기형"),
+    STOCK_INVESTMENT_SCAM     ("스미싱_주식투자 사기형"),
+    IPO_SCAM                  ("스미싱_청약 공모주 사기형"),
+    FALSE_PAYMENT_SCAM        ("스미싱_허위결제사기형");
 
     private final String korName;
 

--- a/src/main/java/com/blockguard/server/domain/analysis/domain/enums/FraudType.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/domain/enums/FraudType.java
@@ -1,5 +1,7 @@
 package com.blockguard.server.domain.analysis.domain.enums;
 
+import com.blockguard.server.global.common.codes.ErrorCode;
+import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -32,9 +34,13 @@ public enum FraudType {
     }
 
     public static FraudType fromKoreanName(String kr) {
+        if (kr == null) {
+            throw new BusinessExceptionHandler(ErrorCode.AI_SERVER_ERROR);
+        }
+        final String kor = kr.trim();
         return Arrays.stream(values())
-                .filter(e -> e.korName.equals(kr))
+                .filter(e -> e.korName.equals(kor))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Unknown FraudType: " + kr));
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.AI_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/blockguard/server/domain/analysis/domain/enums/FraudType.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/domain/enums/FraudType.java
@@ -2,26 +2,28 @@ package com.blockguard.server.domain.analysis.domain.enums;
 
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
 public enum FraudType {
-    INSTITUTION_IMPERSONATION("보이스피싱_기관사칭형"),
-    LOAN_FRAUD               ("보이스피싱_대출사기형"),
-    CARD_COMPANY_IMPERSONATION("보이스피싱_카드사 사칭형"),
-    FAMILY_IMPERSONATION      ("메신저피싱_가족/지인사칭형"),
-    FIRST_BIRTHDAY_INVITE     ("스미싱_돌잔치 초대장형"),
-    MOBILE_WEDDING_INVITE     ("스미싱_모바일 청첩장형"),
-    OBITUARY_MESSAGE          ("스미싱_부고문자형"),
-    FINE_AND_PENALTY          ("스미싱_범칙금/과태료 부과형"),
-    HEALTH_INSURANCE_IMPERSONATION("스미싱_건강보험공단 사칭형"),
-    POLICE_SUMMONS            ("스미싱_경찰출석요구형"),
-    NATIONAL_TAX_SERVICE      ("스미싱_국세청 사칭형"),
-    PART_TIME_SCAM            ("스미싱_알바/부업 사기형"),
-    GOVERNMENT_GRANT_SCAM     ("스미싱_정부지원금 위장형"),
-    DELIVERY_SCAM             ("스미싱_택배사기형"),
-    CRYPTOCURRENCY_SCAM       ("스미싱_가상화폐 사기형"),
-    STOCK_INVESTMENT_SCAM     ("스미싱_주식투자 사기형"),
-    IPO_SCAM                  ("스미싱_청약 공모주 사기형"),
-    FALSE_PAYMENT_SCAM        ("스미싱_허위결제사기형");
+    INSTITUTION_IMPERSONATION("기관사칭형"),
+    LOAN_FRAUD               ("대출사기형"),
+    CARD_COMPANY_IMPERSONATION("카드사 사칭형"),
+    FAMILY_IMPERSONATION      ("가족/지인사칭형"),
+    FIRST_BIRTHDAY_INVITE     ("돌잔치 초대장형"),
+    MOBILE_WEDDING_INVITE     ("모바일 청첩장형"),
+    OBITUARY_MESSAGE          ("부고문자형"),
+    FINE_AND_PENALTY          ("범칙금/과태료 부과형"),
+    HEALTH_INSURANCE_IMPERSONATION("건강보험공단 사칭형"),
+    POLICE_SUMMONS            ("경찰출석요구형"),
+    NATIONAL_TAX_SERVICE      ("국세청 사칭형"),
+    PART_TIME_SCAM            ("알바/부업 사기형"),
+    GOVERNMENT_GRANT_SCAM     ("정부지원금 위장형"),
+    DELIVERY_SCAM             ("택배사기형"),
+    CRYPTOCURRENCY_SCAM       ("가상화폐 사기형"),
+    STOCK_INVESTMENT_SCAM     ("주식투자 사기형"),
+    IPO_SCAM                  ("청약 공모주 사기형"),
+    FALSE_PAYMENT_SCAM        ("허위결제사기형");
 
     private final String korName;
 
@@ -29,4 +31,10 @@ public enum FraudType {
         this.korName = korName;
     }
 
+    public static FraudType fromKoreanName(String kr) {
+        return Arrays.stream(values())
+                .filter(e -> e.korName.equals(kr))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown FraudType: " + kr));
+    }
 }

--- a/src/main/java/com/blockguard/server/domain/analysis/dto/request/FraudAnalysisRequest.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/dto/request/FraudAnalysisRequest.java
@@ -1,5 +1,7 @@
 package com.blockguard.server.domain.analysis.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,14 +12,50 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 public class FraudAnalysisRequest {
+    // (필수) 연락수단
+    @NotBlank
     private String contactMethod;
+
+    // (필수) 상대방
+    @NotBlank
     private String counterpart;
+
+    // (필수/복수가능) 요청받은 행동
+    @NotEmpty
     private List<String> requestedAction;
+
+    // (필수/복수가능) 언급된 내용
+    @NotEmpty
     private List<String> requestedInfo;
-    private String appType; // 선택
-    private Boolean atmGuided; // 선택
-    private String suspiciousLinks; // 선택
-    private String suspiciousPhoneNumbers; // 선택
-    private String messageContent; // 선택
+
+    // (선택) 링크 종류
+    private String linkType;
+
+    // (선택) 개인정보 유출/범죄업무 언급 등 심리적 압박 여부
+    private Boolean pressuredInfo;
+
+    // (선택) 보안점검·금융거래 이유로 앱 설치/링크 접속 유도
+    private Boolean appOrLinkRequest;
+
+    // (선택) 다른 사람에게 연결
+    private Boolean thirdPartyConnect;
+
+    // (선택) 직책을 강조하며 권위적 태도
+    private Boolean authorityPressure;
+
+    // (선택) 범죄 연루·대출 조건 이유로 계좌/링크 입력 유도
+    private Boolean accountOrLinkRequest;
+
+    // (선택) 의심 링크(텍스트)
+    private String suspiciousLinks;
+
+    // (선택) 의심 전화번호(텍스트)
+    private String suspiciousPhoneNumbers;
+
+    // (선택) 문자 내용 입력
+    private String messageContent;
+
+    // (필수) 기타/상황 상세 설명
+    @NotBlank
     private String additionalDescription;
 }

--- a/src/main/java/com/blockguard/server/domain/analysis/dto/response/FraudAnalysisRecordResponse.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/dto/response/FraudAnalysisRecordResponse.java
@@ -1,0 +1,25 @@
+package com.blockguard.server.domain.analysis.dto.response;
+
+import com.blockguard.server.domain.analysis.domain.FraudAnalysisRecord;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class FraudAnalysisRecordResponse {
+    private Long fraudAnalysisRecordId;
+    private String estimatedFraudType;
+    private String riskLevel;
+    private LocalDateTime analyzedAt;
+
+    public static FraudAnalysisRecordResponse from(FraudAnalysisRecord record){
+        return FraudAnalysisRecordResponse.builder()
+                .fraudAnalysisRecordId(record.getId())
+                .analyzedAt(record.getCreatedAt())
+                .estimatedFraudType(record.getEstimatedFraudType().getKorName())
+                .riskLevel(record.getRiskLevel().getValue())
+                .build();
+    }
+}

--- a/src/main/java/com/blockguard/server/domain/analysis/dto/response/FraudAnalysisRecordResponse.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/dto/response/FraudAnalysisRecordResponse.java
@@ -18,7 +18,7 @@ public class FraudAnalysisRecordResponse {
         return FraudAnalysisRecordResponse.builder()
                 .fraudAnalysisRecordId(record.getId())
                 .analyzedAt(record.getCreatedAt())
-                .estimatedFraudType(record.getEstimatedFraudType().getKorName())
+                .estimatedFraudType(record.getEstimatedFraudType() != null ? record.getEstimatedFraudType().getKorName(): null)
                 .riskLevel(record.getRiskLevel().getValue())
                 .build();
     }

--- a/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
+++ b/src/main/java/com/blockguard/server/global/common/codes/SuccessCode.java
@@ -33,7 +33,8 @@ public enum SuccessCode {
     UPDATE_STEP_INFO_SUCCESS(HttpStatus.OK,2022, "신고 단계 정보가 성공적으로 업데이트 되었습니다."),
     GET_NEWS_ARTICLES_SUCCESS(HttpStatus.OK, 2023, "뉴스 목록 조회가 완료되었습니다."),
     CRWAL_DAUM_NEWS_SUCCESS(HttpStatus.OK, 2024, "뉴스 크롤링이 완료되었습니다."),
-    ADMIN_TOKEN_SUCCESS(HttpStatus.OK, 2025, "관리자 토큰이 발급되었습니다.");
+    ADMIN_TOKEN_SUCCESS(HttpStatus.OK, 2025, "관리자 토큰이 발급되었습니다."),
+    GET_ANALYZE_FRAUD_LIST_SUCCESS(HttpStatus.OK, 2026, "사기 분석 기록 조회가 완료되었습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/blockguard/server/global/config/WebMvcConfig.java
+++ b/src/main/java/com/blockguard/server/global/config/WebMvcConfig.java
@@ -2,6 +2,7 @@ package com.blockguard.server.global.config;
 
 import com.blockguard.server.domain.auth.interceptor.AdminCheckInterceptor;
 import com.blockguard.server.global.config.resolver.CurrentUserArgumentResolver;
+import com.blockguard.server.global.config.resolver.OptionalUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -17,6 +18,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     private final long MAX_AGE_SECS = 3600;
     private final CurrentUserArgumentResolver currentUserArgumentResolver;
     private final AdminCheckInterceptor adminCheckInterceptor;
+    private final OptionalUserArgumentResolver optionalUserArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -31,6 +33,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(currentUserArgumentResolver);
+        resolvers.add(optionalUserArgumentResolver);
     }
 
     @Override

--- a/src/main/java/com/blockguard/server/global/config/resolver/OptionalUser.java
+++ b/src/main/java/com/blockguard/server/global/config/resolver/OptionalUser.java
@@ -1,0 +1,11 @@
+package com.blockguard.server.global.config.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OptionalUser {
+}

--- a/src/main/java/com/blockguard/server/global/config/resolver/OptionalUserArgumentResolver.java
+++ b/src/main/java/com/blockguard/server/global/config/resolver/OptionalUserArgumentResolver.java
@@ -1,0 +1,40 @@
+package com.blockguard.server.global.config.resolver;
+
+import com.blockguard.server.domain.user.domain.User;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class OptionalUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(OptionalUser.class)
+                && parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) throws Exception {
+
+        // 현재 로그인된 사용자의 Authentication 정보 꺼내옴
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 인증된 사용자만 User 객체 반환
+        if (authentication != null && authentication.getPrincipal() instanceof User) {
+            return authentication.getPrincipal(); // 로그인된 사용자
+        }
+
+        // 인증되지 않은 경우 null 반환
+        return null;
+    }
+}

--- a/src/main/java/com/blockguard/server/global/config/resolver/OptionalUserArgumentResolver.java
+++ b/src/main/java/com/blockguard/server/global/config/resolver/OptionalUserArgumentResolver.java
@@ -31,13 +31,9 @@ public class OptionalUserArgumentResolver implements HandlerMethodArgumentResolv
         // 현재 로그인된 사용자의 Authentication 정보 꺼내옴
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        // 로그인되지 않은 상태라면
-        if (authentication == null) {
+        // 로그인되지 않은 상태 또는 익명 사용자
+        if (authentication == null || !(authentication.getPrincipal() instanceof User)) {
             return null;
-        }
-        // 인증되지 않은 경우 에러 반환
-        if (!(authentication.getPrincipal() instanceof User)) {
-            throw new BusinessExceptionHandler(ErrorCode.INVALID_TOKEN);
         }
         // 인증된 사용자만 User 객체 반환
         return authentication.getPrincipal(); // 로그인된 사용자

--- a/src/main/java/com/blockguard/server/global/config/resolver/OptionalUserArgumentResolver.java
+++ b/src/main/java/com/blockguard/server/global/config/resolver/OptionalUserArgumentResolver.java
@@ -1,6 +1,8 @@
 package com.blockguard.server.global.config.resolver;
 
 import com.blockguard.server.domain.user.domain.User;
+import com.blockguard.server.global.common.codes.ErrorCode;
+import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,12 +31,15 @@ public class OptionalUserArgumentResolver implements HandlerMethodArgumentResolv
         // 현재 로그인된 사용자의 Authentication 정보 꺼내옴
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        // 인증된 사용자만 User 객체 반환
-        if (authentication != null && authentication.getPrincipal() instanceof User) {
-            return authentication.getPrincipal(); // 로그인된 사용자
+        // 로그인되지 않은 상태라면
+        if (authentication == null) {
+            return null;
         }
-
-        // 인증되지 않은 경우 null 반환
-        return null;
+        // 인증되지 않은 경우 에러 반환
+        if (!(authentication.getPrincipal() instanceof User)) {
+            throw new BusinessExceptionHandler(ErrorCode.INVALID_TOKEN);
+        }
+        // 인증된 사용자만 User 객체 반환
+        return authentication.getPrincipal(); // 로그인된 사용자
     }
 }

--- a/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
@@ -109,6 +109,12 @@ public enum SwaggerResponseDescription {
             ErrorCode.FRAUD_NUMBER_SERVER_ERROR
     ))),
 
+    ANALYZE_FRAUD_FAIL(new LinkedHashSet<>(Set.of(
+            ErrorCode.INVALID_TOKEN,
+            ErrorCode.AI_SERVER_ERROR,
+            ErrorCode.FRAUD_NUMBER_SERVER_ERROR
+    ))),
+
     INVALID_TOKEN(new LinkedHashSet<>(Set.of(
             ErrorCode.INVALID_TOKEN
     )));


### PR DESCRIPTION
## 💻 Related Issue
- closed #49
<br/>

## 🚀 Work Description
- [x] 사기분석 api url/전화번호 추가점수 로직 구현
- 각각 위험으로 판단되면 10점씩 점수에 합산합니다.
- [x] 변경된 사기 설문 반영
- 변경된 설문 그대로 request body를 수정하였습니다.
- 예/아니오 설문지를 gpt 에 보내기 위해 true 경우 문자열로 변경 처리하였습니다.
<img width="555" height="256" alt="스크린샷 2025-08-12 13 25 14" src="https://github.com/user-attachments/assets/445194f4-7a32-40c7-9bd0-4996ee3fc37e" />

- 위험도가 "안전"인 경우 응답의 추정 사기 유형과 키워드 및 설명은 무시하셔도 될 것 같습니다. 

- [x] 사기 분석 내역 리스트 조회 api 구현
<img width="939" height="550" alt="스크린샷 2025-08-12 13 22 27" src="https://github.com/user-attachments/assets/874c9e1f-b1a4-4ace-90fe-4ceab88f5cc9" />

- 안전의 경우 사기 유형의 값이 null로 표시됩니다.
- 최근 분석한 순으로 정렬되어 출력됩니다.

<br/>

## 🙇🏻‍♀️ To Reviewer
-  사기 분석 api 에 token을 선택적으로 허용하는 OptionalUser 어노테이션을 만들어 적용했습니다.
- 사기 분석 내역 저장은 리스트 기반으로 필요한 정보만 저장했습니다. 추후에 단일 내역 조회 디자인이 확정된 후 도메인 변경도 필요할 것 같아서 추후 개발 사항으로 두었습니다!
<br/>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증 사용자 기준 분석 결과 저장 및 사용자별 사기분석 기록 조회 API 추가.
  * 인증 유무를 선택적으로 처리하는 요청 파라미터 지원.

* **개선 사항**
  * 여러 신호(의심 URL/전화번호 + AI 점수)를 합산해 최종 점수(최대 100)와 위험도를 반환하도록 점수 집계 로직 강화.
  * 키워드 추출 대상 확대 및 요청 파라미터 검증 강화.
  * 일부 분석 필드의 비허용 제약 완화로 유연성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->