### PR TITLE
[Fix] 보호자 프로필 사진 업데이트 오류 수정

### DIFF
--- a/src/main/java/com/blockguard/server/domain/guardian/api/GuardianApi.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/api/GuardianApi.java
@@ -2,6 +2,7 @@ package com.blockguard.server.domain.guardian.api;
 
 import com.blockguard.server.domain.guardian.dto.request.CreateGuardianRequest;
 import com.blockguard.server.domain.guardian.dto.request.UpdateGuardianPrimaryRequest;
+import com.blockguard.server.domain.guardian.dto.request.UpdateGuardianRequest;
 import com.blockguard.server.domain.guardian.dto.response.GuardianResponse;
 import com.blockguard.server.domain.guardian.dto.response.GuardiansListResponse;
 import com.blockguard.server.domain.guardian.application.GuardianService;
@@ -47,8 +48,8 @@ public class GuardianApi {
     @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<BaseResponse<GuardianResponse>> updateGuardian(@Parameter(hidden = true) @CurrentUser User user,
                                                                          @PathVariable("id") Long guardianId,
-                                                                         @Valid CreateGuardianRequest createGuardianRequest) {
-        GuardianResponse guardianResponse = guardianService.updateGuardian(user, guardianId, createGuardianRequest);
+                                                                         @Valid UpdateGuardianRequest updateGuardianRequest) {
+        GuardianResponse guardianResponse = guardianService.updateGuardian(user, guardianId, updateGuardianRequest);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.GUARDIAN_UPDATED, guardianResponse));
     }
 

--- a/src/main/java/com/blockguard/server/domain/guardian/application/GuardianService.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/application/GuardianService.java
@@ -63,30 +63,53 @@ public class GuardianService {
                 guardianRepository.existsByUserAndNameAndDeletedAtIsNull(user, request.getName())) {
             throw new BusinessExceptionHandler(ErrorCode.DUPLICATE_GUARDIAN_NAME);
         }
+        // 입력 플래그/파일 상태
+        final boolean wantDefault = Boolean.TRUE.equals(request.getIsDefaultImage());
+        final boolean hasNewFile  = request.getProfileImage() != null && !request.getProfileImage().isEmpty();
+
+        // 기본이미지로 변경 + 새 파일 업로드 동시 요청 불가
+        if (wantDefault && hasNewFile) {
+            throw new BusinessExceptionHandler(ErrorCode.UPDATE_PROFILE_CONFLICT);
+        }
 
         String currentKey = guardian.getProfileImageKey();
         String nextKey = currentKey;
 
         // 기본 이미지로 변경하는 경우
-        if (request.getIsDefaultImage() != null && request.getIsDefaultImage()) {
+        if (wantDefault) {
             nextKey = null;
-            // 예전 이미지 삭제
-            if (currentKey != null){
-                s3Service.delete(currentKey);
-            }
+            // 커밋 후 기존 파일 삭제, 롤백 시 아무것도 안 함
+            registerAfterCommitDelete(currentKey, null);
         }
         // 새 이미지로 변경하는 경우
-        else if (request.getProfileImage() != null && !request.getProfileImage().isEmpty()) {
+        else if (hasNewFile) {
             // 새 이미지 업로드
-            nextKey = s3Service.upload(request.getProfileImage(), "guardians");
-            // 예전 이미지 삭제
-            if (currentKey != null){
-                s3Service.delete(currentKey);
-            }
+            String uploadedKey = s3Service.upload(request.getProfileImage(), "guardians");
+            nextKey = uploadedKey;
+            // 커밋 후 기존 파일 삭제, 롤백 시 방금 올린 파일 삭제
+            registerAfterCommitDelete(currentKey, uploadedKey);
         }
+        // 기존 이미지 유지 (nextKey = currentKey)
         guardian.updateGuardianInfo(request.getName(), request.getPhoneNumber(), nextKey);
         Guardian updated = guardianRepository.save(guardian);
         return GuardianResponse.from(updated, s3Service);
+    }
+
+    // 트랜잭션 커밋 후 기존 키 삭제, 롤백 시 새로 업로드한 키 삭제
+    private void registerAfterCommitDelete(String oldKey, String uploadedKey) {
+        org.springframework.transaction.support.TransactionSynchronizationManager
+                .registerSynchronization(new org.springframework.transaction.support.TransactionSynchronization() {
+                    @Override public void afterCommit() {
+                        if (oldKey != null && !oldKey.equals(uploadedKey)) {
+                            s3Service.delete(oldKey);
+                        }
+                    }
+                    @Override public void afterCompletion(int status) {
+                        if (status == STATUS_ROLLED_BACK && uploadedKey != null) {
+                            s3Service.delete(uploadedKey);
+                        }
+                    }
+                });
     }
 
     @Transactional

--- a/src/main/java/com/blockguard/server/domain/guardian/application/GuardianService.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/application/GuardianService.java
@@ -74,7 +74,9 @@ public class GuardianService {
             if (currentKey != null){
                 s3Service.delete(currentKey);
             }
-        } else if (request.getProfileImage() != null && !request.getProfileImage().isEmpty()) {
+        }
+        // 새 이미지로 변경하는 경우
+        else if (request.getProfileImage() != null && !request.getProfileImage().isEmpty()) {
             // 새 이미지 업로드
             nextKey = s3Service.upload(request.getProfileImage(), "guardians");
             // 예전 이미지 삭제

--- a/src/main/java/com/blockguard/server/domain/guardian/dto/request/CreateGuardianRequest.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/dto/request/CreateGuardianRequest.java
@@ -3,9 +3,11 @@ package com.blockguard.server.domain.guardian.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
@@ -13,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Builder
 public class CreateGuardianRequest {
     @NotBlank
+    @Size(max = 50, message = "name length must be <= 50")
     private String name;
 
     @NotBlank

--- a/src/main/java/com/blockguard/server/domain/guardian/dto/request/UpdateGuardianRequest.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/dto/request/UpdateGuardianRequest.java
@@ -3,9 +3,11 @@ package com.blockguard.server.domain.guardian.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
@@ -13,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Builder
 public class UpdateGuardianRequest {
     @NotBlank
+    @Size(max = 50, message = "name length must be <= 50")
     private String name;
 
     @NotBlank

--- a/src/main/java/com/blockguard/server/domain/guardian/dto/request/UpdateGuardianRequest.java
+++ b/src/main/java/com/blockguard/server/domain/guardian/dto/request/UpdateGuardianRequest.java
@@ -1,0 +1,26 @@
+package com.blockguard.server.domain.guardian.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UpdateGuardianRequest {
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "phoneNumber must match 010-1234-5678 format")
+    private String phoneNumber;
+
+    @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private MultipartFile profileImage;
+
+    private Boolean isDefaultImage;
+}

--- a/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/blockguard/server/global/config/swagger/SwaggerResponseDescription.java
@@ -70,7 +70,8 @@ public enum SwaggerResponseDescription {
             ErrorCode.FILE_NAME_NOT_FOUND,
             ErrorCode.INVALID_DIRECTORY_ROUTE,
             ErrorCode.FILE_SIZE_EXCEEDED,
-            ErrorCode.DUPLICATE_GUARDIAN_NAME
+            ErrorCode.DUPLICATE_GUARDIAN_NAME,
+            ErrorCode.UPDATE_PROFILE_CONFLICT
     ))),
 
     UPDATE_GUARDIAN_PRIMARY_FAIL(new LinkedHashSet<>(Set.of(


### PR DESCRIPTION
## 💻 Related Issue
closed #57 
<br/>

## 🚀 Work Description
- [x] profileImage 가 들어오지 않는 경우, isDefaultImage가 true 면 프로필 이미지 제거, false 면 기존 이미지 유지하는 방식으로 수정하였습니다.
- request body에 isDefaultImage 추가
- S3 삭제는 트랜잭션 커밋 이후에 실행되도록 (롤백 시 새로 올린 파일은 제거) 리펙토링하였습니다.

<br/>

## 🙇🏻‍♀️ To Reviewer
<img width="1025" height="576" alt="스크린샷 2025-08-11 22 31 13" src="https://github.com/user-attachments/assets/7c96c0ad-e1e2-4adc-8f89-d7ac88234dd3" />

<br/>

## ➕ Next

사기 분석 api 수정 마무리

 <br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 보호자 정보 수정에서 기본 이미지 사용/새 이미지 업로드를 선택할 수 있습니다.
  - 수정 전용 요청 형식이 도입되어 수정 흐름이 분리되었습니다.

- 개선
  - 이미지 교체 시 커밋/롤백에 따른 업로드·삭제 정리 로직이 도입되어 안정성이 향상되었습니다.
  - 이름 길이 제한(최대 50자)이 추가되었습니다.

- 문서
  - 프로필 이미지 설정 충돌에 대한 오류 코드와 설명이 API 문서에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->