### PR TITLE
[Feat] 사기분석설문 로직 변경 & 기타 키워드 제외 & 진행중인 긴급 대응 조회 API 응답변경

### DIFF
--- a/src/main/java/com/blockguard/server/domain/report/application/ReportRecordService.java
+++ b/src/main/java/com/blockguard/server/domain/report/application/ReportRecordService.java
@@ -18,8 +18,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -51,11 +53,17 @@ public class ReportRecordService {
                     ReportStepProgress lastProgress = record.getProgressList().stream()
                             .max(Comparator.comparing(ReportStepProgress::getStep))
                             .orElseThrow();
-                    int stepNum = lastProgress.getStep().getStepNumber();
+
+                    LocalDateTime lastUpdatedAt = lastProgress.getCheckboxes().stream()
+                            .map(ReportStepCheckbox::getUpdatedAt)
+                            .filter(Objects::nonNull)
+                            .max(Comparator.naturalOrder())
+                            .orElse(lastProgress.getUpdatedAt());
+
                     return CurrentReportRecordResponse.builder()
                             .reportId(record.getId())
-                            .createdAt(String.valueOf(record.getCreatedAt()))
-                            .step(stepNum)
+                            .updatedAt(lastUpdatedAt.toString())
+                            .step(lastProgress.getStep().getStepNumber())
                             .build();
 
                 });

--- a/src/main/java/com/blockguard/server/domain/report/application/ReportRecordService.java
+++ b/src/main/java/com/blockguard/server/domain/report/application/ReportRecordService.java
@@ -202,7 +202,7 @@ public class ReportRecordService {
                 .step(stepNumber)
                 .checkBoxes(resultRequiredCheckboxes)
                 .recommendedCheckBoxes(resultRecommendedCheckboxes)
-                .createdAt(String.valueOf(record.getCreatedAt()))
+                .createdAt(String.valueOf(progress.getCreatedAt()))
                 .isCompleted(progress.isCompleted())
                 .build();
     }

--- a/src/main/java/com/blockguard/server/domain/report/dto/response/CurrentReportRecordResponse.java
+++ b/src/main/java/com/blockguard/server/domain/report/dto/response/CurrentReportRecordResponse.java
@@ -8,5 +8,5 @@ import lombok.Getter;
 public class CurrentReportRecordResponse {
     private Long reportId;
     private int step;
-    private String createdAt;
+    private String updatedAt;
 }


### PR DESCRIPTION
## 💻 Related Issue
- closed #63 
<br/>

## 🚀 Work Description
- [x] 사기 분석 설문에서 "기타" 키워드가 GPT 프롬프트로 전달되지 않도록 수정했습니다.
- [x] 사기 분석 설문에서 예/아니요로 대답하는 설문은 추가 점수를 주는 방향으로 로직을 변경하였습니다
- [x] 진행중인 긴급 대응 조회 API의 응답 중 createdAt 을 updatedAt 으로 변경하였습니다.
<img width="1076" height="443" alt="스크린샷 2025-08-14 01 14 21" src="https://github.com/user-attachments/assets/d8d47cc0-8db2-4605-b5cc-14294ad2335f" />


<br/>

## 🙇🏻‍♀️ To Reviewer
- 신고조회의 updateAt은 진행중인 신고단계의 체크박스들이 업데이트된 시간을 조회해서 가장 최신시간으로 응답하도록 하였습니다.
- 하나 더 발견한 예비 문제점이.. 신고 단계 업데이트 API 도 응답으로 createdAt를 주고 있는데 사실 updatedAt이 더 맞지 않나싶습니다! 하지만 해당 필드가 활용되진 않을것 같아 수정하진 않았습니다

<br/>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 설문 기반 가점이 최종 사기 위험 점수에 반영됩니다(최대 100). 압박/권위, 제3자 연결/계정·링크 요구 항목 충족 시 각 +5.

* Refactor
  * 보고서 현재 기록 응답 필드가 createdAt에서 updatedAt으로 변경되며, 체크박스들의 최신 갱신 시각을 기준으로 반환합니다.
  * 단계 번호 취득 방식이 간소화되었습니다.
  * 키워드 추출 로직을 모듈화하고 공백/“기타”를 제외해 불필요한 설명성 키워드가 더 이상 노출되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->