### PR TITLE
[Fix] FraudType Enum - UNKNOWN 타입 추가

### DIFF
--- a/src/main/java/com/blockguard/server/domain/analysis/domain/enums/FraudType.java
+++ b/src/main/java/com/blockguard/server/domain/analysis/domain/enums/FraudType.java
@@ -1,7 +1,5 @@
 package com.blockguard.server.domain.analysis.domain.enums;
 
-import com.blockguard.server.global.common.codes.ErrorCode;
-import com.blockguard.server.global.exception.BusinessExceptionHandler;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -26,7 +24,8 @@ public enum FraudType {
     CRYPTOCURRENCY_SCAM       ("가상화폐 사기형"),
     STOCK_INVESTMENT_SCAM     ("주식투자 사기형"),
     IPO_SCAM                  ("청약 공모주 사기형"),
-    FALSE_PAYMENT_SCAM        ("허위결제 사기형");
+    FALSE_PAYMENT_SCAM        ("허위결제 사기형"),
+    UNKNOWN("알 수 없음");
 
     private final String korName;
 
@@ -43,13 +42,13 @@ public enum FraudType {
 
     public static FraudType fromKoreanName(String kr) {
         if (kr == null) {
-            throw new BusinessExceptionHandler(ErrorCode.AI_SERVER_ERROR);
+            return UNKNOWN;
         }
         final String target = squashSpaces(kr.trim());
 
         return Arrays.stream(values())
                 .filter(e -> squashSpaces(e.korName).equals(target))
                 .findFirst()
-                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.AI_SERVER_ERROR));
+                .orElse(UNKNOWN);
     }
 }


### PR DESCRIPTION

## 💻 Related Issue
- closed #68 
<br/>

## 🚀 Work Description
- FraudType에 UNKNOWN을 추가하고, GPT 사기 유형이 파싱이 안되는 경우를 모두 UNKNOWN 반환하도록 처리했습니다.

<br/>

## 🙇🏻‍♀️ To Reviewer
- GPT가 안전으로 판단한 경우 사기 유형 None으로 반환하는 경우 오류가 발생해서 수정했습니다.
- 기존에는 FraudType 변환 실패시 AI 서버와 통신 오류 error 를 던졌지만, 현재는 UNKNOWN 알 수 없음으로 변환되어 나갑니다


<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 사기 유형을 식별할 수 없거나 입력이 누락된 경우, 화면에 “알 수 없음” 상태가 표시됩니다.

* 버그 수정
  * 미일치/누락 입력 시 발생하던 오류를 제거하고, 예외 없이 “알 수 없음”으로 처리해 흐름 중단을 방지했습니다.
  * 불완전한 입력에도 결과가 안정적으로 노출되도록 처리 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->