### PR TITLE
[Refactor] 이메일 중복 API 수정

### DIFF
--- a/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
+++ b/src/main/java/com/blockguard/server/domain/auth/application/AuthService.java
@@ -62,9 +62,13 @@ public class AuthService {
 
 
     public CheckEmailDuplicatedResponse checkEmailDuplicated(CheckEmailDuplicatedRequest checkEmailDuplicatedRequest) {
-        boolean isDuplicated = userRepository.findAnyByEmail(checkEmailDuplicatedRequest.getEmail()).isPresent();
+        Optional<User> user = userRepository.findAnyByEmail(checkEmailDuplicatedRequest.getEmail());
+        boolean isDuplicated = user.isPresent();
+        boolean isDeleted = user.map(User::getDeletedAt).isPresent();
+
         return CheckEmailDuplicatedResponse.builder()
                 .isDuplicated(isDuplicated)
+                .isDeleted(isDeleted)
                 .build();
     }
 

--- a/src/main/java/com/blockguard/server/domain/user/dto/response/CheckEmailDuplicatedResponse.java
+++ b/src/main/java/com/blockguard/server/domain/user/dto/response/CheckEmailDuplicatedResponse.java
@@ -11,4 +11,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CheckEmailDuplicatedResponse {
     private boolean isDuplicated;
+    private boolean isDeleted;
 }


### PR DESCRIPTION
## 💻 Related Issue
closed #74 

<br/>

## 🚀 Work Description
- [x] 회원가입 이메일 중복 여부 확인 시, 탈퇴한 회원의 이메일 중복 여부도 함께 체크
<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이메일 중복 확인 시, 해당 이메일이 삭제된 계정에 속하는지도 함께 제공됩니다. 이를 통해 “이미 사용 중”과 “삭제된 계정의 이메일”을 구분해 안내할 수 있습니다.
- 문서/가이드
  - 클라이언트는 이메일 중복 확인 응답의 추가 상태값을 처리하도록 UI/메시지 로직을 점검하세요.
- 기타 변경
  - 이메일 중복 확인 응답 구조에 삭제 여부 상태가 포함되도록 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->